### PR TITLE
Remove explicit status from return code, instead relying on `TypedError`'s `status()` method.

### DIFF
--- a/contrib/db_pools/codegen/src/database.rs
+++ b/contrib/db_pools/codegen/src/database.rs
@@ -60,15 +60,16 @@ pub fn derive_database(input: TokenStream) -> TokenStream {
 
                     #[rocket::async_trait]
                     impl<'r> rocket::request::FromRequest<'r> for &'r #decorated_type {
-                        type Error = ();
+                        type Error = rocket::http::Status;
 
                         async fn from_request(
                             req: &'r rocket::request::Request<'_>
                         ) -> rocket::request::Outcome<Self, Self::Error> {
                             match #db_ty::fetch(req.rocket()) {
                                 Some(db) => rocket::outcome::Outcome::Success(db),
-                                None => rocket::outcome::Outcome::Error((
-                                    rocket::http::Status::InternalServerError, ()))
+                                None => rocket::outcome::Outcome::Error(
+                                    rocket::http::Status::InternalServerError
+                                )
                             }
                         }
                     }

--- a/contrib/db_pools/lib/src/database.rs
+++ b/contrib/db_pools/lib/src/database.rs
@@ -287,7 +287,9 @@ pub enum ConnectionError<E> {
 }
 
 #[rocket::async_trait]
-impl<'r, D: Database> FromRequest<'r> for Connection<D> {
+impl<'r, D: Database> FromRequest<'r> for Connection<D>
+    where <D::Pool as Pool>::Error: Send + Sync,
+{
     type Error = ConnectionError<<D::Pool as Pool>::Error>;
 
     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {

--- a/contrib/db_pools/lib/src/diesel.rs
+++ b/contrib/db_pools/lib/src/diesel.rs
@@ -92,6 +92,31 @@ pub use diesel_async::AsyncMysqlConnection;
 #[cfg(feature = "diesel_postgres")]
 pub use diesel_async::AsyncPgConnection;
 
+use rocket::TypedError;
+
+/// Wrapper type for diesel errors
+#[derive(Debug, TypedError)]
+pub struct DieselError(diesel::result::Error);
+
+impl std::ops::Deref for DieselError {
+    type Target = diesel::result::Error;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<diesel::result::Error> for DieselError {
+    fn as_ref(&self) -> &diesel::result::Error {
+        &self.0
+    }
+}
+
+impl From<diesel::result::Error> for DieselError {
+    fn from(e: diesel::result::Error) -> Self {
+        Self(e)
+    }
+}
+
 /// Alias of a `Result` with an error type of [`Debug`] for a `diesel::Error`.
 ///
 /// `QueryResult` is a [`Responder`](rocket::response::Responder) when `T` (the
@@ -102,7 +127,8 @@ pub use diesel_async::AsyncPgConnection;
 /// See the [module level docs](self#example) for a usage example.
 ///
 /// [`Debug`]: rocket::response::Debug
-pub type QueryResult<T, E = rocket::response::Debug<diesel::result::Error>> = Result<T, E>;
+// TODO: this needs to change
+pub type QueryResult<T, E = DieselError> = Result<T, E>;
 
 /// Type alias for an `async` pool of MySQL connections for `async` [diesel].
 ///

--- a/contrib/db_pools/lib/src/diesel.rs
+++ b/contrib/db_pools/lib/src/diesel.rs
@@ -27,7 +27,7 @@
 //! # #[macro_use] extern crate rocket;
 //! # #[cfg(feature = "diesel_mysql")] {
 //! use rocket_db_pools::{Database, Connection};
-//! use rocket_db_pools::diesel::{QueryResult, MysqlPool, prelude::*};
+//! use rocket_db_pools::diesel::{QueryResult, DieselError, MysqlPool, prelude::*};
 //!
 //! #[derive(Database)]
 //! #[database("diesel_mysql")]
@@ -57,6 +57,11 @@
 //!         .await?;
 //!
 //!     Ok(format!("{post_ids:?}"))
+//! }
+//!
+//! #[catch(500, error = "<e>")]
+//! fn catch_diesel_error(e: &DieselError) -> String {
+//!     format!("{e:?}")
 //! }
 //! # }
 //! ```
@@ -117,17 +122,14 @@ impl From<diesel::result::Error> for DieselError {
     }
 }
 
-/// Alias of a `Result` with an error type of [`Debug`] for a `diesel::Error`.
+/// Alias of a `Result` with an error type of `diesel::Error`.
 ///
 /// `QueryResult` is a [`Responder`](rocket::response::Responder) when `T` (the
 /// `Ok` value) is a `Responder`. By using this alias as a route handler's
 /// return type, the `?` operator can be applied to fallible `diesel` functions
 /// in the route handler while still providing a valid `Responder` return type.
 ///
-/// See the [module level docs](self#example) for a usage example.
-///
-/// [`Debug`]: rocket::response::Debug
-// TODO: this needs to change
+/// See module level docs for usage, and catching the error type.
 pub type QueryResult<T, E = DieselError> = Result<T, E>;
 
 /// Type alias for an `async` pool of MySQL connections for `async` [diesel].

--- a/contrib/dyn_templates/src/fairing.rs
+++ b/contrib/dyn_templates/src/fairing.rs
@@ -1,6 +1,7 @@
 use rocket::{Rocket, Build, Orbit};
 use rocket::fairing::{self, Fairing, Info, Kind};
 use rocket::figment::{Source, value::magic::RelativePathBuf};
+use rocket::catcher::TypedError;
 use rocket::trace::Trace;
 
 use crate::context::{Callback, Context, ContextManager};
@@ -65,10 +66,13 @@ impl Fairing for TemplateFairing {
     }
 
     #[cfg(debug_assertions)]
-    async fn on_request(&self, req: &mut rocket::Request<'_>, _data: &mut rocket::Data<'_>) {
+    async fn on_request<'r>(&self, req: &'r mut rocket::Request<'_>, _data: &mut rocket::Data<'_>)
+        -> Result<(), Box<dyn TypedError<'r> + 'r>>
+    {
         let cm = req.rocket().state::<ContextManager>()
             .expect("Template ContextManager registered in on_ignite");
 
         cm.reload_if_needed(&self.callback);
+        Ok(())
     }
 }

--- a/contrib/dyn_templates/src/fairing.rs
+++ b/contrib/dyn_templates/src/fairing.rs
@@ -66,13 +66,10 @@ impl Fairing for TemplateFairing {
     }
 
     #[cfg(debug_assertions)]
-    async fn on_request<'r>(&self, req: &'r mut rocket::Request<'_>, _data: &mut rocket::Data<'_>)
-        -> Result<(), Box<dyn TypedError<'r> + 'r>>
-    {
+    async fn on_request(&self, req: &mut rocket::Request<'_>, _data: &mut rocket::Data<'_>) {
         let cm = req.rocket().state::<ContextManager>()
             .expect("Template ContextManager registered in on_ignite");
 
         cm.reload_if_needed(&self.callback);
-        Ok(())
     }
 }

--- a/contrib/dyn_templates/src/fairing.rs
+++ b/contrib/dyn_templates/src/fairing.rs
@@ -1,7 +1,6 @@
 use rocket::{Rocket, Build, Orbit};
 use rocket::fairing::{self, Fairing, Info, Kind};
 use rocket::figment::{Source, value::magic::RelativePathBuf};
-use rocket::catcher::TypedError;
 use rocket::trace::Trace;
 
 use crate::context::{Callback, Context, ContextManager};

--- a/contrib/dyn_templates/src/metadata.rs
+++ b/contrib/dyn_templates/src/metadata.rs
@@ -152,9 +152,9 @@ impl Sentinel for Metadata<'_> {
 /// (`500`) is returned.
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for Metadata<'r> {
-    type Error = ();
+    type Error = Status;
 
-    async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, ()> {
+    async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
         request.rocket().state::<ContextManager>()
             .map(|cm| request::Outcome::Success(Metadata(cm)))
             .unwrap_or_else(|| {
@@ -163,7 +163,7 @@ impl<'r> FromRequest<'r> for Metadata<'r> {
                     To use templates, you must attach `Template::fairing()`."
                 );
 
-                request::Outcome::Error((Status::InternalServerError, ()))
+                request::Outcome::Error(Status::InternalServerError)
             })
     }
 }

--- a/contrib/dyn_templates/src/template.rs
+++ b/contrib/dyn_templates/src/template.rs
@@ -265,6 +265,7 @@ impl Template {
 /// extension and a fixed-size body containing the rendered template. If
 /// rendering fails, an `Err` of `Status::InternalServerError` is returned.
 impl<'r> Responder<'r, 'static> for Template {
+    // TODO: typed: This should be a more useful type
     type Error = std::convert::Infallible;
     fn respond_to(self, req: &'r Request<'_>) -> response::Outcome<'static, Self::Error> {
         if let Some(ctxt) = req.rocket().state::<ContextManager>() {

--- a/contrib/dyn_templates/src/template.rs
+++ b/contrib/dyn_templates/src/template.rs
@@ -265,19 +265,21 @@ impl Template {
 /// extension and a fixed-size body containing the rendered template. If
 /// rendering fails, an `Err` of `Status::InternalServerError` is returned.
 impl<'r> Responder<'r, 'static> for Template {
-    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'static> {
-        let ctxt = req.rocket()
-            .state::<ContextManager>()
-            .ok_or_else(|| {
-                error!(
-                    "uninitialized template context: missing `Template::fairing()`.\n\
-                    To use templates, you must attach `Template::fairing()`."
-                );
+    type Error = std::convert::Infallible;
+    fn respond_to(self, req: &'r Request<'_>) -> response::Outcome<'static, Self::Error> {
+        if let Some(ctxt) = req.rocket().state::<ContextManager>() {
+            match self.finalize(&ctxt.context()) {
+                Ok(v) => v.respond_to(req),
+                Err(s) => response::Outcome::Forward(s),
+            }
+        } else {
+            error!(
+                "uninitialized template context: missing `Template::fairing()`.\n\
+                To use templates, you must attach `Template::fairing()`."
+            );
 
-                Status::InternalServerError
-            })?;
-
-        self.finalize(&ctxt.context())?.respond_to(req)
+            response::Outcome::Forward(Status::InternalServerError)
+        }
     }
 }
 

--- a/contrib/dyn_templates/src/template.rs
+++ b/contrib/dyn_templates/src/template.rs
@@ -265,13 +265,12 @@ impl Template {
 /// extension and a fixed-size body containing the rendered template. If
 /// rendering fails, an `Err` of `Status::InternalServerError` is returned.
 impl<'r> Responder<'r, 'static> for Template {
-    // TODO: typed: This should be a more useful type
-    type Error = std::convert::Infallible;
-    fn respond_to(self, req: &'r Request<'_>) -> response::Outcome<'static, Self::Error> {
+    type Error = Status;
+    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'static, Self::Error> {
         if let Some(ctxt) = req.rocket().state::<ContextManager>() {
             match self.finalize(&ctxt.context()) {
-                Ok(v) => v.respond_to(req),
-                Err(s) => response::Outcome::Forward(s),
+                Ok(v) => v.respond_to(req).map_err(|e| match e {}),
+                Err(s) => Err(s),
             }
         } else {
             error!(
@@ -279,7 +278,7 @@ impl<'r> Responder<'r, 'static> for Template {
                 To use templates, you must attach `Template::fairing()`."
             );
 
-            response::Outcome::Forward(Status::InternalServerError)
+            Err(Status::InternalServerError)
         }
     }
 }

--- a/contrib/sync_db_pools/codegen/src/database.rs
+++ b/contrib/sync_db_pools/codegen/src/database.rs
@@ -112,11 +112,11 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
 
         #[#rocket::async_trait]
         impl<'r> #rocket::request::FromRequest<'r> for #guard_type {
-            type Error = ();
+            type Error = #rocket::http::Status;
 
             async fn from_request(
                 __r: &'r #rocket::request::Request<'_>
-            ) -> #rocket::request::Outcome<Self, ()> {
+            ) -> #rocket::request::Outcome<Self, Self::Error> {
                 <#conn>::from_request(__r).await.map(Self)
             }
         }

--- a/contrib/ws/src/websocket.rs
+++ b/contrib/ws/src/websocket.rs
@@ -239,7 +239,7 @@ impl<'r> FromRequest<'r> for WebSocket {
 
 impl<'r, 'o: 'r> Responder<'r, 'o> for Channel<'o> {
     type Error = std::convert::Infallible;
-    fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'o, Self::Error> {
+    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'o, Self::Error> {
         Response::build()
             .raw_header("Sec-Websocket-Version", "13")
             .raw_header("Sec-WebSocket-Accept", self.ws.key.clone())
@@ -252,7 +252,7 @@ impl<'r, 'o: 'r, S> Responder<'r, 'o> for MessageStream<'o, S>
     where S: futures::Stream<Item = Result<Message>> + Send + 'o
 {
     type Error = std::convert::Infallible;
-    fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'o, Self::Error> {
+    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'o, Self::Error> {
         Response::build()
             .raw_header("Sec-Websocket-Version", "13")
             .raw_header("Sec-WebSocket-Accept", self.ws.key.clone())

--- a/contrib/ws/src/websocket.rs
+++ b/contrib/ws/src/websocket.rs
@@ -238,7 +238,8 @@ impl<'r> FromRequest<'r> for WebSocket {
 }
 
 impl<'r, 'o: 'r> Responder<'r, 'o> for Channel<'o> {
-    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'o> {
+    type Error = std::convert::Infallible;
+    fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'o, Self::Error> {
         Response::build()
             .raw_header("Sec-Websocket-Version", "13")
             .raw_header("Sec-WebSocket-Accept", self.ws.key.clone())
@@ -250,7 +251,8 @@ impl<'r, 'o: 'r> Responder<'r, 'o> for Channel<'o> {
 impl<'r, 'o: 'r, S> Responder<'r, 'o> for MessageStream<'o, S>
     where S: futures::Stream<Item = Result<Message>> + Send + 'o
 {
-    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'o> {
+    type Error = std::convert::Infallible;
+    fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'o, Self::Error> {
         Response::build()
             .raw_header("Sec-Websocket-Version", "13")
             .raw_header("Sec-WebSocket-Accept", self.ws.key.clone())

--- a/core/codegen/src/attribute/catch/mod.rs
+++ b/core/codegen/src/attribute/catch/mod.rs
@@ -85,9 +85,9 @@ pub fn _catch(
     let catcher_response = quote_spanned!(return_type_span => {
         let ___responder = #user_catcher_fn_name(#(#parameter_names),*) #dot_await;
         match #_response::Responder::respond_to(___responder, #__req) {
-            #Outcome::Success(v) => v,
+            #_Ok(v) => v,
             // If the responder fails, we drop any typed error, and convert to 500
-            #Outcome::Error(_) | #Outcome::Forward(_) => return Err(#Status::InternalServerError),
+            #_Err(_) => return #_Err(#Status::InternalServerError),
         }
     });
 

--- a/core/codegen/src/attribute/catch/mod.rs
+++ b/core/codegen/src/attribute/catch/mod.rs
@@ -14,7 +14,7 @@ use super::param::Guard;
 fn error_type(guard: &ErrorGuard) -> TokenStream {
     let ty = &guard.ty;
     quote! {
-        (#_catcher::TypeId::of::<#ty>(), ::std::any::type_name::<#ty>())
+        #_catcher::type_id_of::<#ty>()
     }
 }
 

--- a/core/codegen/src/attribute/catch/mod.rs
+++ b/core/codegen/src/attribute/catch/mod.rs
@@ -31,7 +31,11 @@ fn error_guard_decl(guard: &ErrorGuard) -> TokenStream {
 fn request_guard_decl(guard: &Guard) -> TokenStream {
     let (ident, ty) = (guard.fn_ident.rocketized(), &guard.ty);
     quote_spanned! { ty.span() =>
-        let #ident: #ty = match <#ty as #FromError>::from_error(#__status, #__req, __error_init).await {
+        let #ident: #ty = match <#ty as #FromError>::from_error(
+            #__status,
+            #__req,
+            __error_init
+        ).await {
             #_Result::Ok(__v) => __v,
             #_Result::Err(__e) => {
                 ::rocket::trace::info!(

--- a/core/codegen/src/attribute/catch/parse.rs
+++ b/core/codegen/src/attribute/catch/parse.rs
@@ -56,6 +56,6 @@ impl Attribute {
             .map_err(|diag| diag.help("`#[catch]` expects a status code int or `default`: \
                         `#[catch(404)]` or `#[catch(default)]`"))?;
 
-        Ok(Attribute { status: status.code.0, function, error: status.error })
+        Ok(Attribute { status: status.code.0, function, error: None })
     }
 }

--- a/core/codegen/src/attribute/catch/parse.rs
+++ b/core/codegen/src/attribute/catch/parse.rs
@@ -1,8 +1,12 @@
-use devise::ext::SpanDiagnosticExt;
+use devise::ext::{SpanDiagnosticExt, TypeExt};
 use devise::{Diagnostic, FromMeta, MetaItem, Result, SpanWrapped, Spanned};
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream, Ident};
+use quote::ToTokens;
 
-use crate::attribute::param::Dynamic;
+use crate::attribute::param::{Dynamic, Guard};
+use crate::name::{ArgumentMap, Arguments, Name};
+use crate::proc_macro_ext::Diagnostics;
+use crate::syn_ext::FnArgExt;
 use crate::{http, http_codegen};
 
 /// This structure represents the parsed `catch` attribute and associated items.
@@ -11,7 +15,57 @@ pub struct Attribute {
     pub status: Option<http::Status>,
     /// The function that was decorated with the `catch` attribute.
     pub function: syn::ItemFn,
-    pub error: Option<SpanWrapped<Dynamic>>,
+    pub arguments: Arguments,
+    pub error_guard: Option<ErrorGuard>,
+    pub status_guard: Option<(Name, syn::Ident)>,
+    pub request_guards: Vec<Guard>,
+}
+
+pub struct ErrorGuard {
+    pub span: Span,
+    pub name: Name,
+    pub ident: syn::Ident,
+    pub ty: syn::Type,
+}
+
+impl ErrorGuard {
+    fn new(param: SpanWrapped<Dynamic>, args: &Arguments) -> Result<Self> {
+        if let Some((ident, ty)) = args.map.get(&param.name) {
+            match ty {
+                syn::Type::Reference(syn::TypeReference { elem, .. }) => Ok(Self {
+                    span: param.span(),
+                    name: param.name.clone(),
+                    ident: ident.clone(),
+                    ty: elem.as_ref().clone(),
+                }),
+                ty => {
+                    let msg = format!(
+                        "Error argument must be a reference, found `{}`",
+                        ty.to_token_stream()
+                    );
+                    let diag = param.span()
+                        .error("invalid type")
+                        .span_note(ty.span(), msg)
+                        .help(format!("Perhaps use `&{}` instead", ty.to_token_stream()));
+                    Err(diag)
+                }
+            }
+        } else {
+            let msg = format!("expected argument named `{}` here", param.name);
+            let diag = param.span().error("unused parameter").span_note(args.span, msg);
+            Err(diag)
+        }
+    }
+}
+
+fn status_guard(param: SpanWrapped<Dynamic>, args: &Arguments) -> Result<(Name, Ident)> {
+    if let Some((ident, _)) = args.map.get(&param.name) {
+        Ok((param.name.clone(), ident.clone()))
+    } else {
+        let msg = format!("expected argument named `{}` here", param.name);
+        let diag = param.span().error("unused parameter").span_note(args.span, msg);
+        Err(diag)
+    }
 }
 
 /// We generate a full parser for the meta-item for great error messages.
@@ -19,7 +73,8 @@ pub struct Attribute {
 struct Meta {
     #[meta(naked)]
     code: Code,
-    // error: Option<SpanWrapped<Dynamic>>,
+    error: Option<SpanWrapped<Dynamic>>,
+    status: Option<SpanWrapped<Dynamic>>,
 }
 
 /// `Some` if there's a code, `None` if it's `default`.
@@ -46,16 +101,66 @@ impl FromMeta for Code {
 
 impl Attribute {
     pub fn parse(args: TokenStream, input: proc_macro::TokenStream) -> Result<Self> {
+        let mut diags = Diagnostics::new();
+
         let function: syn::ItemFn = syn::parse(input)
             .map_err(Diagnostic::from)
             .map_err(|diag| diag.help("`#[catch]` can only be used on functions"))?;
 
         let attr: MetaItem = syn::parse2(quote!(catch(#args)))?;
-        let status = Meta::from_meta(&attr)
+        let attr = Meta::from_meta(&attr)
             .map(|meta| meta)
             .map_err(|diag| diag.help("`#[catch]` expects a status code int or `default`: \
                         `#[catch(404)]` or `#[catch(default)]`"))?;
 
-        Ok(Attribute { status: status.code.0, function, error: None })
+        let span = function.sig.paren_token.span.join();
+        let mut arguments = Arguments { map: ArgumentMap::new(), span };
+        for arg in function.sig.inputs.iter() {
+            if let Some((ident, ty)) = arg.typed() {
+                let value = (ident.clone(), ty.with_stripped_lifetimes());
+                arguments.map.insert(Name::from(ident), value);
+            } else {
+                let span = arg.span();
+                let diag = if arg.wild().is_some() {
+                    span.error("handler arguments must be named")
+                        .help("to name an ignored handler argument, use `_name`")
+                } else {
+                    span.error("handler arguments must be of the form `ident: Type`")
+                };
+
+                diags.push(diag);
+            }
+        }
+        // let mut error_guard = None;
+        let error_guard = attr.error.clone()
+            .map(|p| ErrorGuard::new(p, &arguments))
+            .and_then(|p| p.map_err(|e| diags.push(e)).ok());
+        let status_guard = attr.status.clone()
+            .map(|n| status_guard(n, &arguments))
+            .and_then(|p| p.map_err(|e| diags.push(e)).ok());
+        let request_guards = arguments.map.iter()
+            .filter(|(name, _)| {
+                let mut all_other_guards = error_guard.iter()
+                    .map(|g| &g.name)
+                    .chain(status_guard.iter().map(|(n, _)| n));
+
+                all_other_guards.all(|n| n != *name)
+            })
+            .enumerate()
+            .map(|(index, (name, (ident, ty)))| Guard {
+                source: Dynamic { index, name: name.clone(), trailing: false },
+                fn_ident: ident.clone(),
+                ty: ty.clone(),
+            })
+            .collect();
+
+        diags.head_err_or(Attribute {
+            status: attr.code.0,
+            function,
+            arguments,
+            error_guard,
+            status_guard,
+            request_guards,
+        })
     }
 }

--- a/core/codegen/src/attribute/catch/parse.rs
+++ b/core/codegen/src/attribute/catch/parse.rs
@@ -1,6 +1,6 @@
 use devise::ext::{SpanDiagnosticExt, TypeExt};
 use devise::{Diagnostic, FromMeta, MetaItem, Result, SpanWrapped, Spanned};
-use proc_macro2::{Span, TokenStream, Ident};
+use proc_macro2::{Span, TokenStream};
 use quote::ToTokens;
 
 use crate::attribute::param::{Dynamic, Guard};

--- a/core/codegen/src/attribute/catch/parse.rs
+++ b/core/codegen/src/attribute/catch/parse.rs
@@ -57,23 +57,12 @@ impl ErrorGuard {
     }
 }
 
-fn status_guard(param: SpanWrapped<Dynamic>, args: &Arguments) -> Result<(Name, Ident)> {
-    if let Some((ident, _)) = args.map.get(&param.name) {
-        Ok((param.name.clone(), ident.clone()))
-    } else {
-        let msg = format!("expected argument named `{}` here", param.name);
-        let diag = param.span().error("unused parameter").span_note(args.span, msg);
-        Err(diag)
-    }
-}
-
 /// We generate a full parser for the meta-item for great error messages.
 #[derive(FromMeta)]
 struct Meta {
     #[meta(naked)]
     code: Code,
     error: Option<SpanWrapped<Dynamic>>,
-    status: Option<SpanWrapped<Dynamic>>,
 }
 
 /// `Some` if there's a code, `None` if it's `default`.

--- a/core/codegen/src/attribute/catch/parse.rs
+++ b/core/codegen/src/attribute/catch/parse.rs
@@ -17,7 +17,6 @@ pub struct Attribute {
     pub function: syn::ItemFn,
     pub arguments: Arguments,
     pub error_guard: Option<ErrorGuard>,
-    pub status_guard: Option<(Name, syn::Ident)>,
     pub request_guards: Vec<Guard>,
 }
 
@@ -131,18 +130,13 @@ impl Attribute {
                 diags.push(diag);
             }
         }
-        // let mut error_guard = None;
         let error_guard = attr.error.clone()
             .map(|p| ErrorGuard::new(p, &arguments))
-            .and_then(|p| p.map_err(|e| diags.push(e)).ok());
-        let status_guard = attr.status.clone()
-            .map(|n| status_guard(n, &arguments))
             .and_then(|p| p.map_err(|e| diags.push(e)).ok());
         let request_guards = arguments.map.iter()
             .filter(|(name, _)| {
                 let mut all_other_guards = error_guard.iter()
-                    .map(|g| &g.name)
-                    .chain(status_guard.iter().map(|(n, _)| n));
+                    .map(|g| &g.name);
 
                 all_other_guards.all(|n| n != *name)
             })
@@ -159,7 +153,6 @@ impl Attribute {
             function,
             arguments,
             error_guard,
-            status_guard,
             request_guards,
         })
     }

--- a/core/codegen/src/attribute/route/mod.rs
+++ b/core/codegen/src/attribute/route/mod.rs
@@ -115,11 +115,15 @@ fn query_decls(route: &Route) -> Option<TokenStream> {
                 );
                 ::rocket::trace::info!(
                     target: concat!("rocket::codegen::route::", module_path!()),
-                    error_type = ::std::any::type_name_of_val(&__error),
+                    error_type = ::std::any::type_name_of_val(&__e),
                     "Forwarding error"
                 );
 
-                return #Outcome::Forward((#__data, #Status::UnprocessableEntity, #resolve_error!(__e)));
+                return #Outcome::Forward((
+                    #__data,
+                    #Status::UnprocessableEntity,
+                    #resolve_error!(__e)
+                ));
             }
 
             (#(#ident.unwrap()),*)
@@ -207,7 +211,11 @@ fn param_guard_decl(guard: &Guard) -> TokenStream {
                         #i
                     );
 
-                    return #Outcome::Forward((#__data, #Status::InternalServerError, #resolve_error!()));
+                    return #Outcome::Forward((
+                        #__data,
+                        #Status::InternalServerError,
+                        #resolve_error!()
+                    ));
                 }
             }
         },
@@ -226,7 +234,8 @@ fn param_guard_decl(guard: &Guard) -> TokenStream {
 
 fn data_guard_decl(guard: &Guard) -> TokenStream {
     let (ident, ty) = (guard.fn_ident.rocketized(), &guard.ty);
-    define_spanned_export!(ty.span() => __req, __data, display_hack, FromData, Outcome, resolve_error);
+    define_spanned_export!(ty.span() =>
+        __req, __data, display_hack, FromData, Outcome, resolve_error);
 
     quote_spanned! { ty.span() =>
         let #ident: #ty = match <#ty as #FromData>::from_data(#__req, #__data).await {
@@ -251,7 +260,7 @@ fn data_guard_decl(guard: &Guard) -> TokenStream {
                     parameter = stringify!(#ident),
                     type_name = stringify!(#ty),
                     reason = %#display_hack!(&__e),
-                    error_type = ::std::any::type_name_of_val(&__error),
+                    error_type = ::std::any::type_name_of_val(&__e),
                     "data guard failed"
                 );
 

--- a/core/codegen/src/attribute/route/mod.rs
+++ b/core/codegen/src/attribute/route/mod.rs
@@ -236,7 +236,10 @@ fn param_guard_decl(guard: &Guard) -> TokenStream {
                 #_Err(__error) => {
                     // TODO: allocation: (see above)
                     let __reason = ::std::format!("{}", #display_hack!(&__error));
-                    let __error = #_request::FromSegmentsError::new(#__req.routed_segments(#i..), __error);
+                    let __error = #_request::FromSegmentsError::new(
+                            #__req.routed_segments(#i..),
+                            __error
+                        );
                     return #parse_error;
                 },
             }

--- a/core/codegen/src/attribute/route/mod.rs
+++ b/core/codegen/src/attribute/route/mod.rs
@@ -113,6 +113,11 @@ fn query_decls(route: &Route) -> Option<TokenStream> {
                             "{_err}"
                         ); } }
                 );
+                ::rocket::trace::info!(
+                    target: concat!("rocket::codegen::route::", module_path!()),
+                    error_type = ::std::any::type_name_of_val(&__error),
+                    "Forwarding error"
+                );
 
                 return #Outcome::Forward((#__data, #Status::UnprocessableEntity, #resolve_error!(__e)));
             }
@@ -151,6 +156,7 @@ fn request_guard_decl(guard: &Guard) -> TokenStream {
                     parameter = stringify!(#ident),
                     type_name = stringify!(#ty),
                     reason = %#display_hack!(&__e),
+                    error_type = ::std::any::type_name_of_val(&__e),
                     "request guard failed"
                 );
 
@@ -174,8 +180,8 @@ fn param_guard_decl(guard: &Guard) -> TokenStream {
             target: concat!("rocket::codegen::route::", module_path!()),
             parameter = #name,
             type_name = stringify!(#ty),
-            error_ty = std::any::type_name_of_val(&__error),
             reason = %#display_hack!(&__error),
+            error_type = ::std::any::type_name_of_val(&__error),
             "path guard forwarding"
         );
 
@@ -245,6 +251,7 @@ fn data_guard_decl(guard: &Guard) -> TokenStream {
                     parameter = stringify!(#ident),
                     type_name = stringify!(#ty),
                     reason = %#display_hack!(&__e),
+                    error_type = ::std::any::type_name_of_val(&__error),
                     "data guard failed"
                 );
 

--- a/core/codegen/src/attribute/route/mod.rs
+++ b/core/codegen/src/attribute/route/mod.rs
@@ -116,7 +116,7 @@ fn query_decls(route: &Route) -> Option<TokenStream> {
                 let __e = #resolve_error!(__e);
                 ::rocket::trace::info!(
                     target: concat!("rocket::codegen::route::", module_path!()),
-                    error_type = __e.name(),
+                    error_type = __e.name,
                     "Forwarding error"
                 );
 

--- a/core/codegen/src/attribute/route/parse.rs
+++ b/core/codegen/src/attribute/route/parse.rs
@@ -1,6 +1,6 @@
 use devise::{Spanned, SpanWrapped, Result, FromMeta};
 use devise::ext::{SpanDiagnosticExt, TypeExt};
-use indexmap::{IndexSet, IndexMap};
+use indexmap::IndexSet;
 use proc_macro2::Span;
 
 use crate::attribute::suppress::Lint;

--- a/core/codegen/src/attribute/route/parse.rs
+++ b/core/codegen/src/attribute/route/parse.rs
@@ -8,7 +8,7 @@ use crate::proc_macro_ext::Diagnostics;
 use crate::http_codegen::{Method, MediaType};
 use crate::attribute::param::{Parameter, Dynamic, Guard};
 use crate::syn_ext::FnArgExt;
-use crate::name::Name;
+use crate::name::{ArgumentMap, Arguments, Name};
 use crate::http::ext::IntoOwned;
 use crate::http::uri::{Origin, fmt};
 
@@ -29,14 +29,6 @@ pub struct Route {
     pub handler: syn::ItemFn,
     /// The parsed arguments to the user's function.
     pub arguments: Arguments,
-}
-
-type ArgumentMap = IndexMap<Name, (syn::Ident, syn::Type)>;
-
-#[derive(Debug)]
-pub struct Arguments {
-    pub span: Span,
-    pub map: ArgumentMap
 }
 
 /// The parsed `#[route(..)]` attribute.

--- a/core/codegen/src/derive/mod.rs
+++ b/core/codegen/src/derive/mod.rs
@@ -3,3 +3,4 @@ pub mod from_form;
 pub mod from_form_field;
 pub mod responder;
 pub mod uri_display;
+pub mod typed_error;

--- a/core/codegen/src/derive/responder.rs
+++ b/core/codegen/src/derive/responder.rs
@@ -51,7 +51,7 @@ pub fn derive_responder(input: proc_macro::TokenStream) -> TokenStream {
                 fn set_header_tokens<T: ToTokens + Spanned>(item: T) -> TokenStream {
                     quote_spanned!(item.span() => __res.set_header(#item);)
                 }
-                
+
                 let error_outcome = match fields.parent {
                     FieldParent::Variant(p) => {
                         // let name = p.parent.ident.append("Error");
@@ -144,7 +144,8 @@ pub fn derive_responder(input: proc_macro::TokenStream) -> TokenStream {
         //         let variants = item.variants().map(|d| {
         //             let var_name = &d.ident;
         //             let (old, ty) = d.fields().iter().next().map(|f| {
-        //                 let ty = f.ty.with_replaced_lifetimes(Lifetime::new("'o", Span::call_site()));
+        //                 let ty = f.ty.with_replaced_lifetimes(
+        //                        Lifetime::new("'o", Span::call_site()));
         //                 (f.ty.clone(), ty)
         //             }).expect("have at least one field");
         //             let output_life = if old == ty {
@@ -170,7 +171,9 @@ pub fn derive_responder(input: proc_macro::TokenStream) -> TokenStream {
         //             .map(|p| &p.ident)
         //             .filter(|p| generic_used(p, &response_types))
         //             .collect();
-        //         // let bounds: Vec<_> = item.variants().map(|f| bounds_from_fields(f.fields()).expect("Bounds must be valid")).collect();
+        //         let bounds: Vec<_> = item.variants()
+        //             .map(|f| bounds_from_fields(f.fields()).expect("Bounds must be valid"))
+        //             .collect();
         //         let bounds: Vec<_> = item.variants()
         //             .flat_map(|f| responder_types(f.fields()).into_iter())
         //             .map(|t| quote!{#t: #_response::Responder<'r, 'o>,})
@@ -189,14 +192,16 @@ pub fn derive_responder(input: proc_macro::TokenStream) -> TokenStream {
         //             // TODO: validate this impl - roughly each variant must be (at least) inv
         //             // wrt a lifetime, since they impl CanTransendTo<Inv<'r>>
         //             // TODO: also need to add requirements on the type parameters
-        //             unsafe impl<'r, 'o: 'r, #(#type_params: 'r,)*> ::rocket::catcher::Transient for #name<'r, 'o, #(#type_params,)*>
-        //                 where #(#bounds)*
+        //             unsafe impl<'r, 'o: 'r, #(#type_params: 'r,)*> ::rocket::catcher::Transient
+        //                 for #name<'r, 'o, #(#type_params,)*>
+        //                     where #(#bounds)*
         //             {
         //                 type Static = #name<'static, 'static>;
         //                 type Transience = ::rocket::catcher::Inv<'r>;
         //             }
-        //             impl<'r, 'o: 'r, #(#type_params,)*> #TypedError<'r> for #name<'r, 'o, #(#type_params,)*>
-        //                 where #(#bounds)*
+        //             impl<'r, 'o: 'r, #(#type_params,)*> #TypedError<'r>
+        //                 for #name<'r, 'o, #(#type_params,)*>
+        //                     where #(#bounds)*
         //             {
         //                 fn source(&self) -> #_Option<&dyn #TypedError<'r>> {
         //                     match self {

--- a/core/codegen/src/derive/responder.rs
+++ b/core/codegen/src/derive/responder.rs
@@ -1,8 +1,9 @@
 use quote::ToTokens;
 use devise::{*, ext::{TypeExt, SpanDiagnosticExt}};
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
+use syn::{Ident, Lifetime, Type};
 
-use crate::exports::*;
+use crate::{exports::*, syn_ext::IdentExt};
 use crate::syn_ext::{TypeExt as _, GenericsExt as _};
 use crate::http_codegen::{ContentType, Status};
 
@@ -25,32 +26,7 @@ pub fn derive_responder(input: proc_macro::TokenStream) -> TokenStream {
         .type_bound_mapper(MapperBuild::new()
             .try_enum_map(|m, e| mapper::enum_null(m, e))
             .try_fields_map(|_, fields| {
-                let generic_idents = fields.parent.input().generics().type_idents();
-                let lifetime = |ty: &syn::Type| syn::Lifetime::new("'o", ty.span());
-                let mut types = fields.iter()
-                    .map(|f| (f, &f.field.inner.ty))
-                    .map(|(f, ty)| (f, ty.with_replaced_lifetimes(lifetime(ty))));
-
-                let mut bounds = vec![];
-                if let Some((_, ty)) = types.next() {
-                    if !ty.is_concrete(&generic_idents) {
-                        let span = ty.span();
-                        bounds.push(quote_spanned!(span => #ty: #_response::Responder<'r, 'o>));
-                    }
-                }
-
-                for (f, ty) in types {
-                    let attr = FieldAttr::one_from_attrs("response", &f.attrs)?.unwrap_or_default();
-                    if ty.is_concrete(&generic_idents) || attr.ignore {
-                        continue;
-                    }
-
-                    bounds.push(quote_spanned! { ty.span() =>
-                        #ty: ::std::convert::Into<#_http::Header<'o>>
-                    });
-                }
-
-                Ok(quote!(#(#bounds,)*))
+                bounds_from_fields(fields)
             })
         )
         .validator(ValidatorBuild::new()
@@ -75,6 +51,16 @@ pub fn derive_responder(input: proc_macro::TokenStream) -> TokenStream {
                 fn set_header_tokens<T: ToTokens + Spanned>(item: T) -> TokenStream {
                     quote_spanned!(item.span() => __res.set_header(#item);)
                 }
+                
+                let error_outcome = match fields.parent {
+                    FieldParent::Variant(p) => {
+                        // let name = p.parent.ident.append("Error");
+                        // let var_name = &p.ident;
+                        // quote! { #name::#var_name(e) }
+                        quote! { #_catcher::AnyError(#_Box::new(e)) }
+                    },
+                    _ => quote! { e },
+                };
 
                 let attr = ItemAttr::one_from_attrs("response", fields.parent.attrs())?
                     .unwrap_or_default();
@@ -82,9 +68,13 @@ pub fn derive_responder(input: proc_macro::TokenStream) -> TokenStream {
                 let responder = fields.iter().next().map(|f| {
                     let (accessor, ty) = (f.accessor(), f.ty.with_stripped_lifetimes());
                     quote_spanned! { f.span() =>
-                        let mut __res = #try_outcome!(<#ty as #_response::Responder>::respond_to(
+                        let mut __res = match <#ty as #_response::Responder>::respond_to(
                             #accessor, __req
-                        ));
+                        ) {
+                            #Outcome::Success(val) => val,
+                            #Outcome::Error(e) => return #Outcome::Error(#error_outcome),
+                            #Outcome::Forward(f) => return #Outcome::Forward(f),
+                        };
                     }
                 }).expect("have at least one field");
 
@@ -118,14 +108,154 @@ pub fn derive_responder(input: proc_macro::TokenStream) -> TokenStream {
                 type Error = #output;
             })
             .try_struct_map(|_, item| {
-                let responder = item.fields.iter().next().map(|f| {
-                    &f.ty
+                let (old, ty) = item.fields.iter().next().map(|f| {
+                    let ty = f.ty.with_replaced_lifetimes(Lifetime::new("'o", Span::call_site()));
+                    let old = f.ty.with_replaced_lifetimes(Lifetime::new("'a", Span::call_site()));
+                    (old, ty)
                 }).expect("have at least one field");
+                let type_params: Vec<_> = item.generics.type_params().map(|p| &p.ident).collect();
+                let output_life = if old == ty && ty.is_concrete(&type_params) {
+                    quote! { 'static }
+                } else {
+                    quote! { 'o }
+                };
 
                 Ok(quote! {
-                    <#responder as #_response::Responder<'r, 'o>>::Error
+                    <#ty as #_response::Responder<'r, #output_life>>::Error
                 })
             })
+            .enum_map(|_, _item| {
+                // let name = item.ident.append("Error");
+                // let response_types: Vec<_> = item.variants()
+                //     .flat_map(|f| responder_types(f.fields()).into_iter()).collect();
+                // // TODO: add where clauses, and filter for the type params I need
+                // let type_params: Vec<_> = item.generics
+                //     .type_params()
+                //     .map(|p| &p.ident)
+                //     .filter(|p| generic_used(p, &response_types))
+                //     .collect();
+                // quote!{ #name<'r, 'o, #(#type_params,)*> }
+                quote!{ #_catcher::AnyError<'r> }
+            })
         )
+        // .outer_mapper(MapperBuild::new()
+        //     .enum_map(|_, item| {
+        //         let name = item.ident.append("Error");
+        //         let variants = item.variants().map(|d| {
+        //             let var_name = &d.ident;
+        //             let (old, ty) = d.fields().iter().next().map(|f| {
+        //                 let ty = f.ty.with_replaced_lifetimes(Lifetime::new("'o", Span::call_site()));
+        //                 (f.ty.clone(), ty)
+        //             }).expect("have at least one field");
+        //             let output_life = if old == ty {
+        //                 quote! { 'static }
+        //             } else {
+        //                 quote! { 'o }
+        //             };
+        //             quote!{
+        //                 #var_name(<#ty as #_response::Responder<'r, #output_life>>::Error),
+        //             }
+        //         });
+        //         let source = item.variants().map(|d| {
+        //             let var_name = &d.ident;
+        //             quote!{
+        //                 Self::#var_name(v) => #_Some(v),
+        //             }
+        //         });
+        //         let response_types: Vec<_> = item.variants()
+        //             .flat_map(|f| responder_types(f.fields()).into_iter()).collect();
+        //         // TODO: add where clauses, and filter for the type params I need
+        //         let type_params: Vec<_> = item.generics
+        //             .type_params()
+        //             .map(|p| &p.ident)
+        //             .filter(|p| generic_used(p, &response_types))
+        //             .collect();
+        //         // let bounds: Vec<_> = item.variants().map(|f| bounds_from_fields(f.fields()).expect("Bounds must be valid")).collect();
+        //         let bounds: Vec<_> = item.variants()
+        //             .flat_map(|f| responder_types(f.fields()).into_iter())
+        //             .map(|t| quote!{#t: #_response::Responder<'r, 'o>,})
+        //             .collect();
+        //         quote!{
+        //             pub enum #name<'r, 'o, #(#type_params: 'r,)*>
+        //                 where #(#bounds)*
+        //             {
+        //                 #(#variants)*
+        //                 UnusedVariant(
+        //                     // Make this variant impossible to construct
+        //                     ::std::convert::Infallible,
+        //                     ::std::marker::PhantomData<&'o ()>,
+        //                 ),
+        //             }
+        //             // TODO: validate this impl - roughly each variant must be (at least) inv
+        //             // wrt a lifetime, since they impl CanTransendTo<Inv<'r>>
+        //             // TODO: also need to add requirements on the type parameters
+        //             unsafe impl<'r, 'o: 'r, #(#type_params: 'r,)*> ::rocket::catcher::Transient for #name<'r, 'o, #(#type_params,)*>
+        //                 where #(#bounds)*
+        //             {
+        //                 type Static = #name<'static, 'static>;
+        //                 type Transience = ::rocket::catcher::Inv<'r>;
+        //             }
+        //             impl<'r, 'o: 'r, #(#type_params,)*> #TypedError<'r> for #name<'r, 'o, #(#type_params,)*>
+        //                 where #(#bounds)*
+        //             {
+        //                 fn source(&self) -> #_Option<&dyn #TypedError<'r>> {
+        //                     match self {
+        //                         #(#source)*
+        //                         Self::UnusedVariant(f, ..) => match *f { }
+        //                     }
+        //                 }
+        //             }
+        //         }
+        //     })
+        // )
         .to_tokens()
+}
+
+fn generic_used(ident: &Ident, res_types: &[Type]) -> bool {
+    res_types.iter().any(|t| !t.is_concrete(&[ident]))
+}
+
+fn responder_types(fields: Fields<'_>) -> Vec<Type> {
+    let generic_idents = fields.parent.input().generics().type_idents();
+    let lifetime = |ty: &syn::Type| syn::Lifetime::new("'o", ty.span());
+    let mut types = fields.iter()
+        .map(|f| (f, &f.field.inner.ty))
+        .map(|(f, ty)| (f, ty.with_replaced_lifetimes(lifetime(ty))));
+
+    let mut bounds = vec![];
+    if let Some((_, ty)) = types.next() {
+        if !ty.is_concrete(&generic_idents) {
+            bounds.push(ty);
+        }
+    }
+    bounds
+}
+
+fn bounds_from_fields(fields: Fields<'_>) -> Result<TokenStream> {
+    let generic_idents = fields.parent.input().generics().type_idents();
+    let lifetime = |ty: &syn::Type| syn::Lifetime::new("'o", ty.span());
+    let mut types = fields.iter()
+        .map(|f| (f, &f.field.inner.ty))
+        .map(|(f, ty)| (f, ty.with_replaced_lifetimes(lifetime(ty))));
+
+    let mut bounds = vec![];
+    if let Some((_, ty)) = types.next() {
+        if !ty.is_concrete(&generic_idents) {
+            let span = ty.span();
+            bounds.push(quote_spanned!(span => #ty: #_response::Responder<'r, 'o>));
+        }
+    }
+
+    for (f, ty) in types {
+        let attr = FieldAttr::one_from_attrs("response", &f.attrs)?.unwrap_or_default();
+        if ty.is_concrete(&generic_idents) || attr.ignore {
+            continue;
+        }
+
+        bounds.push(quote_spanned! { ty.span() =>
+            #ty: ::std::convert::Into<#_http::Header<'o>>
+        });
+    }
+
+    Ok(quote!(#(#bounds,)*))
 }

--- a/core/codegen/src/derive/responder.rs
+++ b/core/codegen/src/derive/responder.rs
@@ -1,18 +1,23 @@
+// use quote::ToTokens;
+// use crate::{exports::{*, Status as _Status}, syn_ext::IdentExt};
+// use devise::{*, ext::{TypeExt, SpanDiagnosticExt}};
+// use crate::http_codegen::{ContentType, Status};
+
+use syn::{Ident, Lifetime};
 use quote::ToTokens;
 use devise::{*, ext::{TypeExt, SpanDiagnosticExt}};
 use proc_macro2::{Span, TokenStream};
-use syn::Lifetime;
 
-use crate::exports::*;
+use crate::{exports::{*, Status as _Status}, syn_ext::IdentExt};
 use crate::syn_ext::{TypeExt as _, GenericsExt as _};
 use crate::http_codegen::{ContentType, Status};
+
 
 #[derive(Debug, Default, FromMeta)]
 struct ItemAttr {
     content_type: Option<SpanWrapped<ContentType>>,
-    status: Option<SpanWrapped<Status>>,
+    status: Option<SpanWrapped<Status>>,            
 }
-
 #[derive(Default, FromMeta)]
 struct FieldAttr {
     ignore: bool,
@@ -26,7 +31,37 @@ pub fn derive_responder(input: proc_macro::TokenStream) -> TokenStream {
         .type_bound_mapper(MapperBuild::new()
             .try_enum_map(|m, e| mapper::enum_null(m, e))
             .try_fields_map(|_, fields| {
-                bounds_from_fields(fields)
+                let generic_idents = fields.parent.input().generics().type_idents();
+                let lifetime = |ty: &syn::Type| syn::Lifetime::new("'o", ty.span());
+                let mut types = fields.iter()
+                    .map(|f| (f, &f.field.inner.ty))
+                    .map(|(f, ty)| (f, ty.with_replaced_lifetimes(lifetime(ty))));
+
+                let mut bounds = vec![];
+                if let Some((_, ty)) = types.next() {
+                    if !ty.is_concrete(&generic_idents) {
+                        let span = ty.span();
+                        bounds.push(quote_spanned!(span => #ty: #_response::Responder<'r, 'o>));
+                        bounds.push(quote_spanned!(span =>
+                            <
+                                <#ty as #_response::Responder<'r, 'o>>::Error
+                                as #_catcher::Transient
+                            >::Transience: #_catcher::CanTranscendTo<#_catcher::Inv<'r>>));
+                    }
+                }
+
+                for (f, ty) in types {
+                    let attr = FieldAttr::one_from_attrs("response", &f.attrs)?.unwrap_or_default();
+                    if ty.is_concrete(&generic_idents) || attr.ignore {
+                        continue;
+                    }
+
+                    bounds.push(quote_spanned! { ty.span() =>
+                        #ty: ::std::convert::Into<#_http::Header<'o>>
+                    });
+                }
+
+                Ok(quote!(#(#bounds,)*))
             })
         )
         .validator(ValidatorBuild::new()
@@ -53,11 +88,11 @@ pub fn derive_responder(input: proc_macro::TokenStream) -> TokenStream {
                 }
 
                 let error_outcome = match fields.parent {
-                    FieldParent::Variant(_p) => {
-                        // let name = p.parent.ident.append("Error");
-                        // let var_name = &p.ident;
-                        // quote! { #name::#var_name(e) }
-                        quote! { #_catcher::AnyError(#_Box::new(e)) }
+                    FieldParent::Variant(p) => {
+                        let name = p.parent.ident.append("Error");
+                        let var_name = &p.ident;
+                        quote! { #name::#var_name(e) }
+                        // quote! { #_catcher::AnyError(#_Box::new(e)) }
                     },
                     _ => quote! { e },
                 };
@@ -124,144 +159,114 @@ pub fn derive_responder(input: proc_macro::TokenStream) -> TokenStream {
                     <#ty as #_response::Responder<'r, #output_life>>::Error
                 })
             })
-            .enum_map(|_, _item| {
-                // let name = item.ident.append("Error");
-                // let response_types: Vec<_> = item.variants()
-                //     .flat_map(|f| responder_types(f.fields()).into_iter()).collect();
-                // // TODO: add where clauses, and filter for the type params I need
-                // let type_params: Vec<_> = item.generics
-                //     .type_params()
-                //     .map(|p| &p.ident)
-                //     .filter(|p| generic_used(p, &response_types))
-                //     .collect();
-                // quote!{ #name<'r, 'o, #(#type_params,)*> }
-                quote!{ #_catcher::AnyError<'r> }
+            .enum_map(|_, item| {
+                let name = item.ident.append("Error");
+                let type_params: Vec<_> = item.generics.type_params().map(|p| &p.ident).collect();
+                let types = item.variants()
+                    .map(|f| {
+                        let ty = f.fields()
+                        .iter()
+                        .next()
+                        .expect("Variants must have at least one field")
+                        .ty
+                        .with_replaced_lifetimes(Lifetime::new("'o", f.span()));
+
+                        let alt = ty.with_replaced_lifetimes(Lifetime::new("'a", f.span()));
+                        // TODO: typed: Check this logic - it seems to work.
+                        // This isn't safety critical - if it's wrong, it causes compilation failures.
+                        let output = if ty.is_concrete(&type_params) &&  alt == ty {
+                            quote! { 'static }
+                        } else {
+                            quote! { 'o }
+                        };
+                        quote! { <#ty as #_response::Responder<'r, #output>>::Error, }
+                    });
+                quote!{ #name<'r, #(#types)*> }
             })
         )
-        // TODO: typed: We should generate this type, to avoid double-boxing the error
-        // .outer_mapper(MapperBuild::new()
-        //     .enum_map(|_, item| {
-        //         let name = item.ident.append("Error");
-        //         let variants = item.variants().map(|d| {
-        //             let var_name = &d.ident;
-        //             let (old, ty) = d.fields().iter().next().map(|f| {
-        //                 let ty = f.ty.with_replaced_lifetimes(
-        //                        Lifetime::new("'o", Span::call_site()));
-        //                 (f.ty.clone(), ty)
-        //             }).expect("have at least one field");
-        //             let output_life = if old == ty {
-        //                 quote! { 'static }
-        //             } else {
-        //                 quote! { 'o }
-        //             };
-        //             quote!{
-        //                 #var_name(<#ty as #_response::Responder<'r, #output_life>>::Error),
-        //             }
-        //         });
-        //         let source = item.variants().map(|d| {
-        //             let var_name = &d.ident;
-        //             quote!{
-        //                 Self::#var_name(v) => #_Some(v),
-        //             }
-        //         });
-        //         let response_types: Vec<_> = item.variants()
-        //             .flat_map(|f| responder_types(f.fields()).into_iter()).collect();
-        //         // TODO: add where clauses, and filter for the type params I need
-        //         let type_params: Vec<_> = item.generics
-        //             .type_params()
-        //             .map(|p| &p.ident)
-        //             .filter(|p| generic_used(p, &response_types))
-        //             .collect();
-        //         let bounds: Vec<_> = item.variants()
-        //             .map(|f| bounds_from_fields(f.fields()).expect("Bounds must be valid"))
-        //             .collect();
-        //         let bounds: Vec<_> = item.variants()
-        //             .flat_map(|f| responder_types(f.fields()).into_iter())
-        //             .map(|t| quote!{#t: #_response::Responder<'r, 'o>,})
-        //             .collect();
-        //         quote!{
-        //             pub enum #name<'r, 'o, #(#type_params: 'r,)*>
-        //                 where #(#bounds)*
-        //             {
-        //                 #(#variants)*
-        //                 UnusedVariant(
-        //                     // Make this variant impossible to construct
-        //                     ::std::convert::Infallible,
-        //                     ::std::marker::PhantomData<&'o ()>,
-        //                 ),
-        //             }
-        //             // TODO: validate this impl - roughly each variant must be (at least) inv
-        //             // wrt a lifetime, since they impl CanTransendTo<Inv<'r>>
-        //             // TODO: also need to add requirements on the type parameters
-        //             unsafe impl<'r, 'o: 'r, #(#type_params: 'r,)*> ::rocket::catcher::Transient
-        //                 for #name<'r, 'o, #(#type_params,)*>
-        //                     where #(#bounds)*
-        //             {
-        //                 type Static = #name<'static, 'static>;
-        //                 type Transience = ::rocket::catcher::Inv<'r>;
-        //             }
-        //             impl<'r, 'o: 'r, #(#type_params,)*> #TypedError<'r>
-        //                 for #name<'r, 'o, #(#type_params,)*>
-        //                     where #(#bounds)*
-        //             {
-        //                 fn source(&self) -> #_Option<&dyn #TypedError<'r>> {
-        //                     match self {
-        //                         #(#source)*
-        //                         Self::UnusedVariant(f, ..) => match *f { }
-        //                     }
-        //                 }
-        //             }
-        //         }
-        //     })
-        // )
+        .outer_mapper(MapperBuild::new()
+            .enum_map(|_, item| {
+                let name = item.ident.append("Error");
+                let type_params: Vec<Ident> =  item.variants()
+                    .map(|var| var.ident.clone())
+                    .collect();
+                let variants_decl = type_params.iter()
+                    .map(|i| quote! { #i(#i), });
+                let static_params = type_params.iter()
+                    .map(|i| quote! { #i::Static });
+                let transient_bounds = type_params.iter()
+                    .map(|i| quote! {
+                        #i: #_catcher::Transient,
+                        <#i as #_catcher::Transient>::Transience: #_catcher::CanTranscendTo<#_catcher::Inv<'r>>,
+                    });
+                let error_bounds = type_params.iter()
+                    .map(|i| quote! {
+                        #i: #_catcher::TypedError<'r>,
+                        #i: #_catcher::Transient,
+                        <#i as #_catcher::Transient>::Transience: #_catcher::CanTranscendTo<#_catcher::Inv<'r>>,
+                    });
+                quote!{
+                    pub enum #name<'r, #(#type_params,)*> {
+                        #(#variants_decl)*
+                        UnusedVariant(
+                            // Make this variant impossible to construct
+                            ::std::convert::Infallible,
+                            // Needed in case no variants use `'o`
+                            ::std::marker::PhantomData<fn(&'r ())>,
+                        ),
+                    }
+                    // SAFETY: Each variant holds a type `T` that must be
+                    // - T: Transient
+                    // - T::Transience: CanTranscendTo<Inv<'r>>
+                    // - T: 'r
+                    // The UnusedVariant has transience Co<'r>, which can transcend to Inv<'r>
+                    // Because each variant can transcend to Inv<'r>, it is safe to transcend
+                    // the enum as a whole to Inv<'r>
+                    unsafe impl<'r, #(#type_params: 'r,)*> ::rocket::catcher::Transient
+                        for #name<'r, #(#type_params,)*>
+                            where #(#transient_bounds)*
+                    {
+                        type Static = #name<'static, #(#static_params,)*>;
+                        type Transience = ::rocket::catcher::Inv<'r>;
+                    }
+
+                    impl<'r, #(#type_params,)*> #TypedError<'r>
+                        for #name<'r, #(#type_params,)*>
+                            where #(#error_bounds)*
+                    {
+                        fn source(&'r self) -> #_Option<&dyn #TypedError<'r>> {
+                            match self {
+                                #(Self::#type_params(v) => v.source(),)*
+                                Self::UnusedVariant(f, ..) => match *f { }
+                            }
+                        }
+
+                        fn name(&self) -> &'static str {
+                            match self {
+                                #(Self::#type_params(v) => v.name(),)*
+                                Self::UnusedVariant(f, ..) => match *f { }
+                            }
+                        }
+
+                        fn respond_to(
+                            &self,
+                            __req: &'r #_request::Request<'_>
+                        ) -> #_Result<#Response<'r>, #_Status> {
+                            match self {
+                                #(Self::#type_params(v) => v.respond_to(__req),)*
+                                Self::UnusedVariant(f, ..) => match *f { }
+                            }
+                        }
+
+                        fn status(&self) -> #_Status {
+                            match self {
+                                #(Self::#type_params(v) => v.status(),)*
+                                Self::UnusedVariant(f, ..) => match *f { }
+                            }
+                        }
+                    }
+                }
+            })
+        )
         .to_tokens()
-}
-
-// fn generic_used(ident: &Ident, res_types: &[Type]) -> bool {
-//     res_types.iter().any(|t| !t.is_concrete(&[ident]))
-// }
-
-// fn responder_types(fields: Fields<'_>) -> Vec<Type> {
-//     let generic_idents = fields.parent.input().generics().type_idents();
-//     let lifetime = |ty: &syn::Type| syn::Lifetime::new("'o", ty.span());
-//     let mut types = fields.iter()
-//         .map(|f| (f, &f.field.inner.ty))
-//         .map(|(f, ty)| (f, ty.with_replaced_lifetimes(lifetime(ty))));
-
-//     let mut bounds = vec![];
-//     if let Some((_, ty)) = types.next() {
-//         if !ty.is_concrete(&generic_idents) {
-//             bounds.push(ty);
-//         }
-//     }
-//     bounds
-// }
-
-fn bounds_from_fields(fields: Fields<'_>) -> Result<TokenStream> {
-    let generic_idents = fields.parent.input().generics().type_idents();
-    let lifetime = |ty: &syn::Type| syn::Lifetime::new("'o", ty.span());
-    let mut types = fields.iter()
-        .map(|f| (f, &f.field.inner.ty))
-        .map(|(f, ty)| (f, ty.with_replaced_lifetimes(lifetime(ty))));
-
-    let mut bounds = vec![];
-    if let Some((_, ty)) = types.next() {
-        if !ty.is_concrete(&generic_idents) {
-            let span = ty.span();
-            bounds.push(quote_spanned!(span => #ty: #_response::Responder<'r, 'o>));
-        }
-    }
-
-    for (f, ty) in types {
-        let attr = FieldAttr::one_from_attrs("response", &f.attrs)?.unwrap_or_default();
-        if ty.is_concrete(&generic_idents) || attr.ignore {
-            continue;
-        }
-
-        bounds.push(quote_spanned! { ty.span() =>
-            #ty: ::std::convert::Into<#_http::Header<'o>>
-        });
-    }
-
-    Ok(quote!(#(#bounds,)*))
 }

--- a/core/codegen/src/derive/typed_error.rs
+++ b/core/codegen/src/derive/typed_error.rs
@@ -37,7 +37,9 @@ pub fn derive_typed_error(input: proc_macro::TokenStream) -> TokenStream {
         .inner_mapper(MapperBuild::new()
             .with_output(|_, output| quote! {
                 #[allow(unused_variables)]
-                fn respond_to(&self, request: &'r #Request<'_>) -> #_Result<#Response<'r>, #_Status> {
+                fn respond_to(&self, request: &'r #Request<'_>)
+                    -> #_Result<#Response<'r>, #_Status>
+                {
                     #output
                 }
             })
@@ -76,7 +78,9 @@ pub fn derive_typed_error(input: proc_macro::TokenStream) -> TokenStream {
                                 None => Member::Unnamed(Index { index: field.index as u32, span })
                             };
 
-                            source = Some(quote_spanned!(span => #_Some(&self.#member as &dyn #TypedError<'r>)));
+                            source = Some(quote_spanned!(
+                                span => #_Some(&self.#member as &dyn #TypedError<'r>
+                            )));
                         }
                     }
                 }

--- a/core/codegen/src/derive/typed_error.rs
+++ b/core/codegen/src/derive/typed_error.rs
@@ -1,0 +1,150 @@
+use devise::{*, ext::SpanDiagnosticExt};
+use proc_macro2::TokenStream;
+use syn::{ConstParam, Index, LifetimeParam, Member, TypeParam};
+
+use crate::exports::{*, Status as _Status};
+use crate::http_codegen::Status;
+
+#[derive(Debug, Default, FromMeta)]
+struct ItemAttr {
+    status: Option<SpanWrapped<Status>>,
+    // TODO: support an option to avoid implementing Transient
+    // no_transient: bool,
+}
+
+#[derive(Default, FromMeta)]
+struct FieldAttr {
+    source: bool,
+}
+
+pub fn derive_typed_error(input: proc_macro::TokenStream) -> TokenStream {
+    let impl_tokens = quote!(impl<'r> #TypedError<'r>);
+    let typed_error: TokenStream = DeriveGenerator::build_for(input.clone(), impl_tokens)
+        .support(Support::Struct | Support::Enum | Support::Lifetime | Support::Type)
+        .replace_generic(0, 0)
+        .type_bound_mapper(MapperBuild::new()
+            .input_map(|_, i| {
+                let bounds = i.generics().type_params().map(|g| &g.ident);
+                quote! { #(#bounds: 'static,)* }
+            })
+        )
+        .validator(ValidatorBuild::new()
+            .input_validate(|_, i| match i.generics().lifetimes().count() > 1 {
+                true => Err(i.generics().span().error("only one lifetime is supported")),
+                false => Ok(())
+            })
+        )
+        .inner_mapper(MapperBuild::new()
+            .with_output(|_, output| quote! {
+                #[allow(unused_variables)]
+                fn respond_to(&self, request: &'r #Request<'_>) -> #_Result<#Response<'r>, #_Status> {
+                    #output
+                }
+            })
+            .try_fields_map(|_, fields| {
+                let item = ItemAttr::one_from_attrs("error", fields.parent.attrs())?;
+                Ok(item.map_or_else(|| quote! {
+                    #_Err(#_Status::InternalServerError)
+                }, |ItemAttr { status, ..}| quote! {
+                    #_Err(#status)
+                }))
+            })
+        )
+        .inner_mapper(MapperBuild::new()
+            .with_output(|_, output| quote! {
+                fn source(&'r self) -> #_Option<&'r (dyn #TypedError<'r> + 'r)> {
+                    #output
+                }
+            })
+            .try_fields_map(|_, fields| {
+                let mut source = None;
+                for field in fields.iter() {
+                    if FieldAttr::one_from_attrs("error", &field.attrs)?.is_some_and(|a| a.source) {
+                        if source.is_some() {
+                            return Err(Diagnostic::spanned(
+                                field.span(),
+                                Level::Error,
+                                "Only one field may be declared as `#[error(source)]`"));
+                        }
+                        if let FieldParent::Variant(_) = field.parent {
+                            let name = field.match_ident();
+                            source = Some(quote! { #_Some(#name as &dyn #TypedError<'r>) })
+                        } else {
+                            let span = field.field.span().into();
+                            let member = match field.ident {
+                                Some(ref ident) => Member::Named(ident.clone()),
+                                None => Member::Unnamed(Index { index: field.index as u32, span })
+                            };
+
+                            source = Some(quote_spanned!(span => #_Some(&self.#member as &dyn #TypedError<'r>)));
+                        }
+                    }
+                }
+                Ok(source.unwrap_or_else(|| quote! { #_None }))
+            })
+        )
+        .inner_mapper(MapperBuild::new()
+            .with_output(|_, output| quote! {
+                fn status(&self) -> #_Status { #output }
+            })
+            .try_fields_map(|_, fields| {
+                let item = ItemAttr::one_from_attrs("error", fields.parent.attrs())?;
+                Ok(item.map_or_else(|| quote! {
+                    #_Status::InternalServerError
+                }, |ItemAttr { status, ..}| quote! {
+                    #status
+                }))
+            })
+        )
+        .to_tokens();
+    let impl_tokens = quote!(unsafe impl #_catcher::Transient);
+    let transient: TokenStream = DeriveGenerator::build_for(input, impl_tokens)
+        .support(Support::Struct | Support::Enum | Support::Lifetime | Support::Type)
+        .replace_generic(1, 0)
+        .type_bound_mapper(MapperBuild::new()
+            .input_map(|_, i| {
+                let bounds = i.generics().type_params().map(|g| &g.ident);
+                quote! { #(#bounds: 'static,)* }
+            })
+        )
+        .validator(ValidatorBuild::new()
+            .input_validate(|_, i| match i.generics().lifetimes().count() > 1 {
+                true => Err(i.generics().span().error("only one lifetime is supported")),
+                false => Ok(())
+            })
+        )
+        .inner_mapper(MapperBuild::new()
+            .with_output(|_, output| quote! {
+                #output
+            })
+            .input_map(|_, input| {
+                let name = input.ident();
+                let args = input.generics()
+                    .params
+                    .iter()
+                    .map(|g| {
+                        match g {
+                            syn::GenericParam::Lifetime(_) => quote!{ 'static },
+                            syn::GenericParam::Type(TypeParam { ident, .. }) => quote! { #ident },
+                            syn::GenericParam::Const(ConstParam { .. }) => todo!(),
+                        }
+                    });
+                let trans = input.generics()
+                    .lifetimes()
+                    .map(|LifetimeParam { lifetime, .. }| quote!{#_catcher::Inv<#lifetime>});
+                quote!{
+                    type Static = #name <#(#args)*>;
+                    type Transience = (#(#trans,)*);
+                }
+            })
+        )
+        // TODO: hack to generate unsafe impl
+        .outer_mapper(MapperBuild::new()
+            .input_map(|_, _| quote!{ unsafe })
+        )
+        .to_tokens();
+    quote!{
+        #typed_error
+        #transient
+    }
+}

--- a/core/codegen/src/derive/typed_error.rs
+++ b/core/codegen/src/derive/typed_error.rs
@@ -25,7 +25,7 @@ pub fn derive_typed_error(input: proc_macro::TokenStream) -> TokenStream {
         .type_bound_mapper(MapperBuild::new()
             .input_map(|_, i| {
                 let bounds = i.generics().type_params().map(|g| &g.ident);
-                quote! { #(#bounds: 'static,)* }
+                quote! { #(#bounds: ::std::marker::Send + ::std::marker::Sync + 'static,)* }
             })
         )
         .validator(ValidatorBuild::new()

--- a/core/codegen/src/exports.rs
+++ b/core/codegen/src/exports.rs
@@ -88,6 +88,7 @@ define_exported_paths! {
     _ExitCode => ::std::process::ExitCode,
     _trace => ::rocket::trace,
     display_hack => ::rocket::error::display_hack,
+    try_outcome => ::rocket::outcome::try_outcome,
     BorrowMut => ::std::borrow::BorrowMut,
     Outcome => ::rocket::outcome::Outcome,
     FromForm => ::rocket::form::FromForm,

--- a/core/codegen/src/exports.rs
+++ b/core/codegen/src/exports.rs
@@ -102,6 +102,9 @@ define_exported_paths! {
     Route => ::rocket::Route,
     Catcher => ::rocket::Catcher,
     Status => ::rocket::http::Status,
+    ErrorResolver => ::rocket::catcher::resolution::Resolve,
+    ErrorDefault => ::rocket::catcher::resolution::DefaultTypeErase,
+    ErasedErrorRef => ::rocket::catcher::ErasedErrorRef,
 }
 
 macro_rules! define_spanned_export {

--- a/core/codegen/src/exports.rs
+++ b/core/codegen/src/exports.rs
@@ -93,6 +93,7 @@ define_exported_paths! {
     Outcome => ::rocket::outcome::Outcome,
     FromForm => ::rocket::form::FromForm,
     FromRequest => ::rocket::request::FromRequest,
+    FromError => ::rocket::catcher::FromError,
     FromData => ::rocket::data::FromData,
     FromSegments => ::rocket::request::FromSegments,
     FromParam => ::rocket::request::FromParam,

--- a/core/codegen/src/exports.rs
+++ b/core/codegen/src/exports.rs
@@ -86,6 +86,7 @@ define_exported_paths! {
     _Vec => ::std::vec::Vec,
     _Cow => ::std::borrow::Cow,
     _ExitCode => ::std::process::ExitCode,
+    _trace => ::rocket::trace,
     display_hack => ::rocket::error::display_hack,
     BorrowMut => ::std::borrow::BorrowMut,
     Outcome => ::rocket::outcome::Outcome,
@@ -103,7 +104,7 @@ define_exported_paths! {
     Catcher => ::rocket::Catcher,
     Status => ::rocket::http::Status,
     resolve_error => ::rocket::catcher::resolve_typed_catcher,
-    ErasedError => ::rocket::catcher::ErasedError,
+    TypedError => ::rocket::catcher::TypedError,
 }
 
 macro_rules! define_spanned_export {

--- a/core/codegen/src/exports.rs
+++ b/core/codegen/src/exports.rs
@@ -102,9 +102,8 @@ define_exported_paths! {
     Route => ::rocket::Route,
     Catcher => ::rocket::Catcher,
     Status => ::rocket::http::Status,
-    ErrorResolver => ::rocket::catcher::resolution::Resolve,
-    ErrorDefault => ::rocket::catcher::resolution::DefaultTypeErase,
-    ErasedErrorRef => ::rocket::catcher::ErasedErrorRef,
+    resolve_error => ::rocket::catcher::resolve_typed_catcher,
+    ErasedError => ::rocket::catcher::ErasedError,
 }
 
 macro_rules! define_spanned_export {

--- a/core/codegen/src/lib.rs
+++ b/core/codegen/src/lib.rs
@@ -301,7 +301,7 @@ route_attribute!(options => Method::Options);
 ///     format!("Sorry, {} does not exist.", uri)
 /// }
 ///
-/// #[catch(default, status = "<status>")]
+/// #[catch(default)]
 /// fn default(status: Status, uri: &Origin) -> String {
 ///     format!("{} ({})", status, uri)
 /// }
@@ -316,11 +316,11 @@ route_attribute!(options => Method::Options);
 ///
 /// STATUS := valid HTTP status code (integer in [200, 599])
 /// parameter := 'rank' '=' INTEGER
-///            | 'status' '=' '"' SINGLE_PARAM '"'
 ///            | 'error' '=' '"' SINGLE_PARAM '"'
 /// SINGLE_PARAM := '<' IDENT '>'
 /// ```
 ///
+/// TODO: typed: docs
 /// # Typing Requirements
 ///
 /// Every identifier, except for `_`, that appears in a dynamic parameter, must appear
@@ -329,11 +329,10 @@ route_attribute!(options => Method::Options);
 /// The type of each function argument corresponding to a dynamic parameter is required to
 /// meet specific requirements.
 ///
-/// - `status`: Must be [`Status`].
-/// - `error`: Must be a reference to a type that implements `Transient`. See
+/// - `error`: Must be a reference to a type that implements `TypedError`. See
 ///   [Typed catchers](Self#Typed-catchers) for more info.
 ///
-/// All other arguments must implement [`FromRequest`].
+/// All other arguments must implement [`FromError`], (or [`FromRequest`]).
 ///
 /// A route argument declared a `_` must not appear in the function argument list and has no typing requirements.
 ///
@@ -1011,7 +1010,7 @@ pub fn derive_responder(input: TokenStream) -> TokenStream {
 
 /// Derive for the [`TypedError`] trait.
 ///
-/// TODO: Full documentation
+/// TODO: typed: Full documentation
 /// [`TypedError`]: ../rocket/catcher/trait.TypedError.html
 #[proc_macro_derive(TypedError, attributes(error))]
 pub fn derive_typed_error(input: TokenStream) -> TokenStream {

--- a/core/codegen/src/lib.rs
+++ b/core/codegen/src/lib.rs
@@ -320,10 +320,9 @@ route_attribute!(options => Method::Options);
 /// SINGLE_PARAM := '<' IDENT '>'
 /// ```
 ///
-/// TODO: typed: docs (links)
 /// # Typing Requirements
 ///
-/// The type of the `error` arguement must be a reference to a type that implements `TypedError`. See
+/// The type of the `error` arguement must be a reference to a type that implements [`TypedError`]. See
 /// [Typed catchers](Self#Typed-catchers) for more info.
 ///
 /// All other arguments must implement [`FromError`], (or [`FromRequest`]).
@@ -336,8 +335,8 @@ route_attribute!(options => Method::Options);
 /// error types. This is accomplished using the [`TypedError`] trait.
 /// When a [`FromRequest`], [`FromParam`],
 /// [`FromSegments`], [`FromForm`], or [`FromData`] implementation fails or
-/// forwards, Rocket will convert to the error type to `dyn TypedError`, if the
-/// error type implements `TypedError`.
+/// forwards, Rocket will convert to the error type to [`dyn TypedError`], if the
+/// error type implements [`TypedError`].
 ///
 /// Only a single error type can be carried by a request - if a route forwards,
 /// and another route is attempted, any error produced by the second route
@@ -345,16 +344,14 @@ route_attribute!(options => Method::Options);
 ///
 /// There are two convient types - [`FromParam`] types actually generate a
 /// [`FromParamError<T>`] (although you can still catch the inner `T` type).
-/// Likewise [`FromSegements`] actually generates [`FromSegementsError<T>`].
+/// Likewise [`FromSegments`] actually generates [`FromSegmentsError<T>`].
 ///
 /// ## Custom error types
 ///
-/// All[^transient-impls] error types that Rocket itself produces implement
+/// All error types that Rocket itself produces implement
 /// [`TypedError`], and can therefore be caught by a typed catcher. If you have
 /// a custom guard of any type, you can implement [`TypedError`] using the derive
 /// macro.
-///
-/// [^transient-impls]: As of writing, this is a WIP.
 ///
 /// # Semantics
 ///
@@ -382,7 +379,15 @@ route_attribute!(options => Method::Options);
 /// [`Catcher`]: ../rocket/struct.Catcher.html
 /// [`Response`]: ../rocket/struct.Response.html
 /// [`Responder`]: ../rocket/response/trait.Responder.html
+/// [`FromError`]: ../rocket/catcher/trait.FromError.html
 /// [`FromRequest`]: ../rocket/request/trait.FromRequest.html
+/// [`FromParam`]: ../rocket/request/trait.FromParam.html
+/// [`FromSegments`]: ../rocket/request/trait.FromSegments.html
+/// [`FromData`]: ../rocket/data/trait.FromData.html
+/// [`TypedError`]: ../rocket/catcher/trait.TypedError.html
+/// [`dyn TypedError`]: ../rocket/catcher/trait.TypedError.html
+/// [`FromParamError<T>`]: ../rocket/request/struct.FromParamError.html
+/// [`FromSegmentsError<T>`]: ../rocket/request/struct.FromSegmentsError.html
 #[proc_macro_attribute]
 pub fn catch(args: TokenStream, input: TokenStream) -> TokenStream {
     emit!(attribute::catch::catch_attribute(args, input))
@@ -470,7 +475,7 @@ pub fn async_test(args: TokenStream, input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// For all other cases, use [`#[launch]`](launch) instead.
+/// For all other cases, use [`#[launch]`](macro@launch) instead.
 ///
 /// The function attributed with `#[rocket::main]` _must_ be `async` and _must_
 /// be called `main`. Violation of either results in a compile-time error.

--- a/core/codegen/src/lib.rs
+++ b/core/codegen/src/lib.rs
@@ -1009,6 +1009,15 @@ pub fn derive_responder(input: TokenStream) -> TokenStream {
     emit!(derive::responder::derive_responder(input))
 }
 
+/// Derive for the [`TypedError`] trait.
+///
+/// TODO: Full documentation
+/// [`TypedError`]: ../rocket/catcher/trait.TypedError.html
+#[proc_macro_derive(TypedError, attributes(error))]
+pub fn derive_typed_error(input: TokenStream) -> TokenStream {
+    emit!(derive::typed_error::derive_typed_error(input))
+}
+
 /// Derive for the [`UriDisplay<Query>`] trait.
 ///
 /// The [`UriDisplay<Query>`] derive can be applied to enums and structs. When

--- a/core/codegen/src/name.rs
+++ b/core/codegen/src/name.rs
@@ -1,7 +1,17 @@
 use crate::http::uncased::UncasedStr;
 
+use indexmap::IndexMap;
 use syn::{Ident, ext::IdentExt};
 use proc_macro2::{Span, TokenStream};
+
+pub type ArgumentMap = IndexMap<Name, (syn::Ident, syn::Type)>;
+
+#[derive(Debug)]
+pub struct Arguments {
+    pub span: Span,
+    pub map: ArgumentMap
+}
+
 
 /// A "name" read by codegen, which may or may not be an identifier. A `Name` is
 /// typically constructed indirectly via FromMeta, or From<Ident> or directly

--- a/core/codegen/tests/async-routes.rs
+++ b/core/codegen/tests/async-routes.rs
@@ -2,7 +2,6 @@
 
 #[macro_use] extern crate rocket;
 use rocket::http::uri::Origin;
-use rocket::request::Request;
 
 async fn noop() { }
 
@@ -19,7 +18,7 @@ async fn repeated_query(sort: Vec<&str>) -> &str {
 }
 
 #[catch(404)]
-async fn not_found(req: &Request<'_>) -> String {
+async fn not_found(uri: &Origin<'_>) -> String {
     noop().await;
-    format!("{} not found", req.uri())
+    format!("{} not found", uri)
 }

--- a/core/codegen/tests/catcher.rs
+++ b/core/codegen/tests/catcher.rs
@@ -13,9 +13,9 @@ use rocket::http::{Status, uri::Origin};
 fn not_found_0() -> &'static str { "404-0" }
 #[catch(404)]
 fn not_found_1() -> &'static str { "404-1" }
-#[catch(404, status = "<_s>")]
+#[catch(404)]
 fn not_found_2(_s: Status) -> &'static str { "404-2" }
-#[catch(default, status = "<_s>")]
+#[catch(default)]
 fn all(_s: Status, uri: &Origin<'_>) -> String { uri.to_string() }
 
 #[test]
@@ -41,13 +41,13 @@ fn test_simple_catchers() {
 }
 
 #[get("/<code>")] fn forward(code: u16) -> Status { Status::new(code) }
-#[catch(400, status = "<status>")]
+#[catch(400)]
 fn forward_400(status: Status) -> String { status.code.to_string() }
-#[catch(404, status = "<status>")]
+#[catch(404)]
 fn forward_404(status: Status) -> String { status.code.to_string() }
-#[catch(444, status = "<status>")]
+#[catch(444)]
 fn forward_444(status: Status) -> String { status.code.to_string() }
-#[catch(500, status = "<status>")]
+#[catch(500)]
 fn forward_500(status: Status) -> String { status.code.to_string() }
 
 #[test]
@@ -70,7 +70,7 @@ fn test_status_param() {
 #[catch(404)]
 fn bad_req_untyped() -> &'static str { "404" }
 #[catch(404, error = "<_e>")]
-fn bad_req_string(_e: &String) -> &'static str { "404 String" }
+fn bad_req_string(_e: &std::io::Error) -> &'static str { "404 String" }
 #[catch(404, error = "<_e>")]
 fn bad_req_tuple(_e: &()) -> &'static str { "404 ()" }
 

--- a/core/codegen/tests/catcher.rs
+++ b/core/codegen/tests/catcher.rs
@@ -5,14 +5,18 @@
 
 #[macro_use] extern crate rocket;
 
-use rocket::{Request, Rocket, Build};
+use rocket::{Rocket, Build};
 use rocket::local::blocking::Client;
-use rocket::http::Status;
+use rocket::http::{Status, uri::Origin};
 
-#[catch(404)] fn not_found_0() -> &'static str { "404-0" }
-#[catch(404)] fn not_found_1(_: &Request<'_>) -> &'static str { "404-1" }
-#[catch(404)] fn not_found_2(_: Status, _: &Request<'_>) -> &'static str { "404-2" }
-#[catch(default)] fn all(_: Status, r: &Request<'_>) -> String { r.uri().to_string() }
+#[catch(404)]
+fn not_found_0() -> &'static str { "404-0" }
+#[catch(404)]
+fn not_found_1() -> &'static str { "404-1" }
+#[catch(404, status = "<_s>")]
+fn not_found_2(_s: Status) -> &'static str { "404-2" }
+#[catch(default, status = "<_s>")]
+fn all(_s: Status, uri: &Origin<'_>) -> String { uri.to_string() }
 
 #[test]
 fn test_simple_catchers() {
@@ -37,10 +41,14 @@ fn test_simple_catchers() {
 }
 
 #[get("/<code>")] fn forward(code: u16) -> Status { Status::new(code) }
-#[catch(400)] fn forward_400(status: Status, _: &Request<'_>) -> String { status.code.to_string() }
-#[catch(404)] fn forward_404(status: Status, _: &Request<'_>) -> String { status.code.to_string() }
-#[catch(444)] fn forward_444(status: Status, _: &Request<'_>) -> String { status.code.to_string() }
-#[catch(500)] fn forward_500(status: Status, _: &Request<'_>) -> String { status.code.to_string() }
+#[catch(400, status = "<status>")]
+fn forward_400(status: Status) -> String { status.code.to_string() }
+#[catch(404, status = "<status>")]
+fn forward_404(status: Status) -> String { status.code.to_string() }
+#[catch(444, status = "<status>")]
+fn forward_444(status: Status) -> String { status.code.to_string() }
+#[catch(500, status = "<status>")]
+fn forward_500(status: Status) -> String { status.code.to_string() }
 
 #[test]
 fn test_status_param() {
@@ -60,11 +68,11 @@ fn test_status_param() {
 }
 
 #[catch(404)]
-fn bad_req_untyped(_: Status, _: &Request<'_>) -> &'static str { "404" }
-#[catch(404)]
-fn bad_req_string(_: &String, _: Status, _: &Request<'_>) -> &'static str { "404 String" }
-#[catch(404)]
-fn bad_req_tuple(_: &(), _: Status, _: &Request<'_>) -> &'static str { "404 ()" }
+fn bad_req_untyped() -> &'static str { "404" }
+#[catch(404, error = "<_e>")]
+fn bad_req_string(_e: &String) -> &'static str { "404 String" }
+#[catch(404, error = "<_e>")]
+fn bad_req_tuple(_e: &()) -> &'static str { "404 ()" }
 
 #[test]
 fn test_typed_catchers() {

--- a/core/codegen/tests/route-data.rs
+++ b/core/codegen/tests/route-data.rs
@@ -17,7 +17,7 @@ struct Simple<'r>(&'r str);
 
 #[async_trait]
 impl<'r> FromData<'r> for Simple<'r> {
-    type Error = std::io::Error;
+    type Error = <&'r str as FromData<'r>>::Error;
 
     async fn from_data(req: &'r Request<'_>, data: Data<'r>) -> data::Outcome<'r, Self> {
         <&'r str>::from_data(req, data).await.map(Simple)

--- a/core/codegen/tests/route-raw.rs
+++ b/core/codegen/tests/route-raw.rs
@@ -1,6 +1,7 @@
 #[macro_use] extern crate rocket;
 
 use rocket::local::blocking::Client;
+use rocket_http::Method;
 
 // Test that raw idents can be used for route parameter names
 
@@ -15,8 +16,8 @@ fn swap(r#raw: String, bare: String) -> String {
 }
 
 #[catch(400)]
-fn catch(r#raw: &rocket::Request<'_>) -> String {
-    format!("{}", raw.method())
+fn catch(r#raw: Method) -> String {
+    format!("{}", raw)
 }
 
 #[test]

--- a/core/codegen/tests/route.rs
+++ b/core/codegen/tests/route.rs
@@ -24,7 +24,7 @@ struct Simple(String);
 
 #[async_trait]
 impl<'r> FromData<'r> for Simple {
-    type Error = std::io::Error;
+    type Error = <String as FromData<'r>>::Error;
 
     async fn from_data(req: &'r Request<'_>, data: Data<'r>) -> data::Outcome<'r, Self> {
         String::from_data(req, data).await.map(Simple)

--- a/core/codegen/tests/typed_error.rs
+++ b/core/codegen/tests/typed_error.rs
@@ -1,0 +1,69 @@
+#[macro_use] extern crate rocket;
+use rocket::catcher::TypedError;
+use rocket::http::Status;
+
+fn boxed_error<'r>(_val: Box<dyn TypedError<'r> + 'r>) {}
+
+#[derive(TypedError)]
+pub enum Foo<'r> {
+    First(String),
+    Second(Vec<u8>),
+    Third {
+        #[error(source)]
+        responder: std::io::Error,
+    },
+    #[error(status = 400)]
+    Fourth {
+        string: &'r str,
+    },
+}
+
+#[test]
+fn validate_foo() {
+    let first = Foo::First("".into());
+    assert_eq!(first.status(), Status::InternalServerError);
+    assert!(first.source().is_none());
+    boxed_error(Box::new(first));
+    let second = Foo::Second(vec![]);
+    assert_eq!(second.status(), Status::InternalServerError);
+    assert!(second.source().is_none());
+    boxed_error(Box::new(second));
+    let third = Foo::Third {
+        responder: std::io::Error::new(std::io::ErrorKind::NotFound, ""),
+    };
+    assert_eq!(third.status(), Status::InternalServerError);
+    assert!(std::ptr::eq(
+        third.source().unwrap(),
+        if let Foo::Third { responder } = &third { responder } else { panic!() }
+    ));
+    boxed_error(Box::new(third));
+    let fourth = Foo::Fourth { string: "" };
+    assert_eq!(fourth.status(), Status::BadRequest);
+    assert!(fourth.source().is_none());
+    boxed_error(Box::new(fourth));
+}
+
+#[derive(TypedError)]
+pub struct InfallibleError {
+    #[error(source)]
+    _inner: std::convert::Infallible,
+}
+
+#[derive(TypedError)]
+pub struct StaticError {
+    #[error(source)]
+    inner: std::string::FromUtf8Error,
+}
+
+#[test]
+fn validate_static() {
+    let val = StaticError {
+        inner: String::from_utf8(vec![0xFF]).unwrap_err(),
+    };
+    assert_eq!(val.status(), Status::InternalServerError);
+    assert!(std::ptr::eq(
+        val.source().unwrap(),
+        &val.inner,
+    ));
+    boxed_error(Box::new(val));
+}

--- a/core/codegen/tests/ui-fail-nightly/catch.stderr
+++ b/core/codegen/tests/ui-fail-nightly/catch.stderr
@@ -62,20 +62,15 @@ error: unexpected attribute parameter: `message`
    |
    = help: `#[catch]` expects a status code int or `default`: `#[catch(404)]` or `#[catch(default)]`
 
-error[E0308]: arguments to this function are incorrect
-  --> tests/ui-fail-nightly/catch.rs:30:4
+error[E0277]: the trait bound `bool: FromError<'_>` is not satisfied
+  --> tests/ui-fail-nightly/catch.rs:30:35
    |
 30 | fn f3(_request: &Request, _other: bool) { }
-   |    ^^           --------          ---- an argument of type `bool` is missing
-   |                 |
-   |                 unexpected argument of type `Status`
+   |                                   ^^^^ the trait `FromRequest<'_>` is not implemented for `bool`, which is required by `bool: FromError<'_>`
    |
-note: function defined here
-  --> tests/ui-fail-nightly/catch.rs:30:4
-   |
-30 | fn f3(_request: &Request, _other: bool) { }
-   |    ^^ ------------------  ------------
-help: provide the argument
-   |
-29 | f3(bool, /* bool */)
-   |
+   = help: the following other types implement trait `FromError<'r>`:
+             &'r (dyn TypedError<'r> + 'r)
+             &'r rocket::Request<'r>
+             Status
+             std::option::Option<&'r (dyn TypedError<'r> + 'r)>
+   = note: required for `bool` to implement `FromError<'_>`

--- a/core/codegen/tests/ui-fail-nightly/catch_type_errors.stderr
+++ b/core/codegen/tests/ui-fail-nightly/catch_type_errors.stderr
@@ -17,6 +17,24 @@ error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied
             <Arc<str> as Responder<'r, 'static>>
           and $N others
 
+error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied
+ --> tests/ui-fail-nightly/catch_type_errors.rs:5:1
+  |
+5 | #[catch(404)]
+  | ^^^^^^^^^^^^^ the trait `Responder<'_, '_>` is not implemented for `usize`
+  |
+  = help: the following other types implement trait `Responder<'r, 'o>`:
+            <&'o [u8] as Responder<'r, 'o>>
+            <&'o str as Responder<'r, 'o>>
+            <() as Responder<'r, 'static>>
+            <(ContentType, R) as Responder<'r, 'o>>
+            <(Status, R) as Responder<'r, 'o>>
+            <Accepted<R> as Responder<'r, 'o>>
+            <Arc<[u8]> as Responder<'r, 'static>>
+            <Arc<str> as Responder<'r, 'static>>
+          and $N others
+  = note: this error originates in the attribute macro `catch` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: the trait bound `bool: Responder<'_, '_>` is not satisfied
   --> tests/ui-fail-nightly/catch_type_errors.rs:11:30
    |
@@ -36,19 +54,36 @@ error[E0277]: the trait bound `bool: Responder<'_, '_>` is not satisfied
              <Arc<str> as Responder<'r, 'static>>
            and $N others
 
-error[E0308]: mismatched types
+error[E0277]: the trait bound `bool: Responder<'_, '_>` is not satisfied
+  --> tests/ui-fail-nightly/catch_type_errors.rs:10:1
+   |
+10 | #[catch(404)]
+   | ^^^^^^^^^^^^^ the trait `Responder<'_, '_>` is not implemented for `bool`
+   |
+   = help: the following other types implement trait `Responder<'r, 'o>`:
+             <&'o [u8] as Responder<'r, 'o>>
+             <&'o str as Responder<'r, 'o>>
+             <() as Responder<'r, 'static>>
+             <(ContentType, R) as Responder<'r, 'o>>
+             <(Status, R) as Responder<'r, 'o>>
+             <Accepted<R> as Responder<'r, 'o>>
+             <Arc<[u8]> as Responder<'r, 'static>>
+             <Arc<str> as Responder<'r, 'static>>
+           and $N others
+   = note: this error originates in the attribute macro `catch` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `bool: FromError<'_>` is not satisfied
   --> tests/ui-fail-nightly/catch_type_errors.rs:16:17
    |
 16 | fn f3(_request: bool) -> usize {
-   |    --           ^^^^ expected `bool`, found `&Request<'_>`
-   |    |
-   |    arguments to this function are incorrect
+   |                 ^^^^ the trait `FromRequest<'_>` is not implemented for `bool`, which is required by `bool: FromError<'_>`
    |
-note: function defined here
-  --> tests/ui-fail-nightly/catch_type_errors.rs:16:4
-   |
-16 | fn f3(_request: bool) -> usize {
-   |    ^^ --------------
+   = help: the following other types implement trait `FromError<'r>`:
+             &'r (dyn TypedError<'r> + 'r)
+             &'r rocket::Request<'r>
+             Status
+             std::option::Option<&'r (dyn TypedError<'r> + 'r)>
+   = note: required for `bool` to implement `FromError<'_>`
 
 error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied
   --> tests/ui-fail-nightly/catch_type_errors.rs:16:26
@@ -70,6 +105,24 @@ error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied
            and $N others
 
 error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied
+  --> tests/ui-fail-nightly/catch_type_errors.rs:15:1
+   |
+15 | #[catch(404)]
+   | ^^^^^^^^^^^^^ the trait `Responder<'_, '_>` is not implemented for `usize`
+   |
+   = help: the following other types implement trait `Responder<'r, 'o>`:
+             <&'o [u8] as Responder<'r, 'o>>
+             <&'o str as Responder<'r, 'o>>
+             <() as Responder<'r, 'static>>
+             <(ContentType, R) as Responder<'r, 'o>>
+             <(Status, R) as Responder<'r, 'o>>
+             <Accepted<R> as Responder<'r, 'o>>
+             <Arc<[u8]> as Responder<'r, 'static>>
+             <Arc<str> as Responder<'r, 'static>>
+           and $N others
+   = note: this error originates in the attribute macro `catch` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied
   --> tests/ui-fail-nightly/catch_type_errors.rs:21:12
    |
 20 | #[catch(404)]
@@ -87,3 +140,21 @@ error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied
              <Arc<[u8]> as Responder<'r, 'static>>
              <Arc<str> as Responder<'r, 'static>>
            and $N others
+
+error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied
+  --> tests/ui-fail-nightly/catch_type_errors.rs:20:1
+   |
+20 | #[catch(404)]
+   | ^^^^^^^^^^^^^ the trait `Responder<'_, '_>` is not implemented for `usize`
+   |
+   = help: the following other types implement trait `Responder<'r, 'o>`:
+             <&'o [u8] as Responder<'r, 'o>>
+             <&'o str as Responder<'r, 'o>>
+             <() as Responder<'r, 'static>>
+             <(ContentType, R) as Responder<'r, 'o>>
+             <(Status, R) as Responder<'r, 'o>>
+             <Accepted<R> as Responder<'r, 'o>>
+             <Arc<[u8]> as Responder<'r, 'static>>
+             <Arc<str> as Responder<'r, 'static>>
+           and $N others
+   = note: this error originates in the attribute macro `catch` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/core/codegen/tests/ui-fail-nightly/responder-types.stderr
+++ b/core/codegen/tests/ui-fail-nightly/responder-types.stderr
@@ -1,8 +1,61 @@
+error[E0277]: the trait bound `u8: Responder<'r, 'static>` is not satisfied
+ --> tests/ui-fail-nightly/responder-types.rs:3:10
+  |
+3 | #[derive(Responder)]
+  |          ^^^^^^^^^ the trait `Responder<'r, 'static>` is not implemented for `u8`
+  |
+  = help: the following other types implement trait `Responder<'r, 'o>`:
+            <&'o [u8] as Responder<'r, 'o>>
+            <&'o str as Responder<'r, 'o>>
+            <() as Responder<'r, 'static>>
+            <(ContentType, R) as Responder<'r, 'o>>
+            <(Status, R) as Responder<'r, 'o>>
+            <Accepted<R> as Responder<'r, 'o>>
+            <Arc<[u8]> as Responder<'r, 'static>>
+            <Arc<str> as Responder<'r, 'static>>
+          and $N others
+  = note: this error originates in the derive macro `Responder` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `u8: Responder<'r, 'static>` is not satisfied
+  --> tests/ui-fail-nightly/responder-types.rs:14:10
+   |
+14 | #[derive(Responder)]
+   |          ^^^^^^^^^ the trait `Responder<'r, 'static>` is not implemented for `u8`
+   |
+   = help: the following other types implement trait `Responder<'r, 'o>`:
+             <&'o [u8] as Responder<'r, 'o>>
+             <&'o str as Responder<'r, 'o>>
+             <() as Responder<'r, 'static>>
+             <(ContentType, R) as Responder<'r, 'o>>
+             <(Status, R) as Responder<'r, 'o>>
+             <Accepted<R> as Responder<'r, 'o>>
+             <Arc<[u8]> as Responder<'r, 'static>>
+             <Arc<str> as Responder<'r, 'static>>
+           and $N others
+   = note: this error originates in the derive macro `Responder` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: the trait bound `u8: Responder<'_, '_>` is not satisfied
  --> tests/ui-fail-nightly/responder-types.rs:5:12
   |
 5 |     thing: u8,
   |            ^^ the trait `Responder<'_, '_>` is not implemented for `u8`
+  |
+  = help: the following other types implement trait `Responder<'r, 'o>`:
+            <&'o [u8] as Responder<'r, 'o>>
+            <&'o str as Responder<'r, 'o>>
+            <() as Responder<'r, 'static>>
+            <(ContentType, R) as Responder<'r, 'o>>
+            <(Status, R) as Responder<'r, 'o>>
+            <Accepted<R> as Responder<'r, 'o>>
+            <Arc<[u8]> as Responder<'r, 'static>>
+            <Arc<str> as Responder<'r, 'static>>
+          and $N others
+
+error[E0277]: the trait bound `u8: Responder<'_, '_>` is not satisfied
+ --> tests/ui-fail-nightly/responder-types.rs:5:5
+  |
+5 |     thing: u8,
+  |     ^^^^^^^^^ the trait `Responder<'_, '_>` is not implemented for `u8`
   |
   = help: the following other types implement trait `Responder<'r, 'o>`:
             <&'o [u8] as Responder<'r, 'o>>
@@ -78,6 +131,23 @@ note: required by a bound in `Response::<'r>::set_header`
    |     pub fn set_header<'h: 'r, H: Into<Header<'h>>>(&mut self, header: H) -> bool {
    |                                  ^^^^^^^^^^^^^^^^ required by this bound in `Response::<'r>::set_header`
 
+error[E0277]: the trait bound `u8: Responder<'_, '_>` is not satisfied
+  --> tests/ui-fail-nightly/responder-types.rs:16:5
+   |
+16 |     thing: u8,
+   |     ^^^^^^^^^ the trait `Responder<'_, '_>` is not implemented for `u8`
+   |
+   = help: the following other types implement trait `Responder<'r, 'o>`:
+             <&'o [u8] as Responder<'r, 'o>>
+             <&'o str as Responder<'r, 'o>>
+             <() as Responder<'r, 'static>>
+             <(ContentType, R) as Responder<'r, 'o>>
+             <(Status, R) as Responder<'r, 'o>>
+             <Accepted<R> as Responder<'r, 'o>>
+             <Arc<[u8]> as Responder<'r, 'static>>
+             <Arc<str> as Responder<'r, 'static>>
+           and $N others
+
 error[E0277]: the trait bound `Header<'_>: From<std::string::String>` is not satisfied
   --> tests/ui-fail-nightly/responder-types.rs:24:5
    |
@@ -119,9 +189,9 @@ error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied
              <Arc<[u8]> as Responder<'r, 'static>>
              <Arc<str> as Responder<'r, 'static>>
            and $N others
-note: required by a bound in `route::handler::<impl Outcome<Response<'o>, Status, (rocket::Data<'o>, Status)>>::from`
+note: required by a bound in `route::handler::<impl Outcome<Response<'o>, (Status, std::option::Option<Box<(dyn TypedError<'o> + 'o)>>), (rocket::Data<'o>, Status, std::option::Option<Box<(dyn TypedError<'o> + 'o)>>)>>::from`
   --> $WORKSPACE/core/lib/src/route/handler.rs
    |
    |     pub fn from<R: Responder<'r, 'o>>(req: &'r Request<'_>, responder: R) -> Outcome<'r> {
-   |                    ^^^^^^^^^^^^^^^^^ required by this bound in `route::handler::<impl Outcome<Response<'o>, Status, (Data<'o>, Status)>>::from`
+   |                    ^^^^^^^^^^^^^^^^^ required by this bound in `route::handler::<impl Outcome<Response<'o>, (Status, Option<Box<dyn TypedError<'o>>>), (Data<'o>, Status, Option<Box<dyn TypedError<'o>>>)>>::from`
    = note: this error originates in the attribute macro `get` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/core/codegen/tests/ui-fail-nightly/typed-catchers.rs
+++ b/core/codegen/tests/ui-fail-nightly/typed-catchers.rs
@@ -1,0 +1,1 @@
+../ui-fail/typed-catchers.rs

--- a/core/codegen/tests/ui-fail-nightly/typed-catchers.stderr
+++ b/core/codegen/tests/ui-fail-nightly/typed-catchers.stderr
@@ -1,0 +1,160 @@
+error: invalid type
+ --> tests/ui-fail-nightly/typed-catchers.rs:7:28
+  |
+7 | #[catch(default, error = "<foo>")]
+  |                            ^^^
+  |
+note: Error argument must be a reference, found `std :: io :: Error`
+ --> tests/ui-fail-nightly/typed-catchers.rs:8:18
+  |
+8 | fn isnt_ref(foo: std::io::Error) -> &'static str {
+  |                  ^^^^^^^^^^^^^^
+  = help: Perhaps use `&std :: io :: Error` instead
+
+error: invalid type
+  --> tests/ui-fail-nightly/typed-catchers.rs:12:28
+   |
+12 | #[catch(default, error = "<foo>")]
+   |                            ^^^
+   |
+note: Error argument must be a reference, found `Foo`
+  --> tests/ui-fail-nightly/typed-catchers.rs:13:27
+   |
+13 | fn isnt_ref_or_error(foo: Foo) -> &'static str {
+   |                           ^^^
+   = help: Perhaps use `&Foo` instead
+
+error[E0277]: the trait bound `Foo: TypedError<'_>` is not satisfied
+  --> tests/ui-fail-nightly/typed-catchers.rs:19:1
+   |
+19 | #[catch(default, error = "<foo>")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `TypedError<'_>` is not implemented for `Foo`
+   |
+   = help: the following other types implement trait `TypedError<'r>`:
+             <() as TypedError<'r>>
+             <Accepted<R> as TypedError<'_>>
+             <AnyError<'r> as TypedError<'r>>
+             <BadRequest<R> as TypedError<'_>>
+             <Conflict<R> as TypedError<'_>>
+             <Created<R> as TypedError<'_>>
+             <Errors<'r> as TypedError<'r>>
+             <Forbidden<R> as TypedError<'_>>
+           and $N others
+note: required by a bound in `type_id_of`
+  --> $WORKSPACE/core/lib/src/catcher/types.rs
+   |
+   | pub fn type_id_of<'r, T: TypedError<'r> + Transient + 'r>() -> (TypeId, &'static str) {
+   |                          ^^^^^^^^^^^^^^ required by this bound in `type_id_of`
+   = note: this error originates in the attribute macro `catch` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Foo: Transient` is not satisfied
+  --> tests/ui-fail-nightly/typed-catchers.rs:19:1
+   |
+19 | #[catch(default, error = "<foo>")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `rocket::catcher::Static` is not implemented for `Foo`, which is required by `Foo: Transient`
+   |
+   = help: the following other types implement trait `Transient`:
+             &'_a &'_b &'a [T]
+             &'_a &'_b &'a mut [T]
+             &'_a &'_b &'a mut str
+             &'_a &'_b &'a str
+             &'_a &'_b ()
+             &'_a &'_b AddrParseError
+             &'_a &'_b Box<str>
+             &'_a &'_b FromUtf16Error
+           and $N others
+   = note: required for `Foo` to implement `Transient`
+note: required by a bound in `type_id_of`
+  --> $WORKSPACE/core/lib/src/catcher/types.rs
+   |
+   | pub fn type_id_of<'r, T: TypedError<'r> + Transient + 'r>() -> (TypeId, &'static str) {
+   |                                           ^^^^^^^^^ required by this bound in `type_id_of`
+   = note: this error originates in the attribute macro `catch` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Foo: TypedError<'_>` is not satisfied
+  --> tests/ui-fail-nightly/typed-catchers.rs:19:1
+   |
+19 | #[catch(default, error = "<foo>")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `TypedError<'_>` is not implemented for `Foo`
+   |
+   = help: the following other types implement trait `TypedError<'r>`:
+             <() as TypedError<'r>>
+             <Accepted<R> as TypedError<'_>>
+             <AnyError<'r> as TypedError<'r>>
+             <BadRequest<R> as TypedError<'_>>
+             <Conflict<R> as TypedError<'_>>
+             <Created<R> as TypedError<'_>>
+             <Errors<'r> as TypedError<'r>>
+             <Forbidden<R> as TypedError<'_>>
+           and $N others
+note: required by a bound in `downcast`
+  --> $WORKSPACE/core/lib/src/catcher/types.rs
+   |
+   | pub fn downcast<'r, T: TypedError<'r> + Transient + 'r>(v: Option<&'r dyn TypedError<'r>>) -> Option<&'r T>
+   |                        ^^^^^^^^^^^^^^ required by this bound in `downcast`
+   = note: this error originates in the attribute macro `catch` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Foo: rocket::catcher::Static` is not satisfied
+  --> tests/ui-fail-nightly/typed-catchers.rs:19:1
+   |
+19 | #[catch(default, error = "<foo>")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `rocket::catcher::Static` is not implemented for `Foo`, which is required by `Foo: Transient`
+   |
+   = help: the following other types implement trait `rocket::catcher::Static`:
+             ()
+             Accepted<R>
+             AddrParseError
+             BadRequest<R>
+             Box<(dyn std::any::Any + 'static)>
+             Box<str>
+             Conflict<R>
+             Created<R>
+           and $N others
+   = note: required for `Foo` to implement `Transient`
+   = note: this error originates in the attribute macro `catch` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Foo: FromError<'_>` is not satisfied
+  --> tests/ui-fail-nightly/typed-catchers.rs:25:37
+   |
+25 | fn doesnt_implement_from_error(foo: Foo) -> &'static str {
+   |                                     ^^^ the trait `FromRequest<'_>` is not implemented for `Foo`, which is required by `Foo: FromError<'_>`
+   |
+   = help: the following other types implement trait `FromError<'r>`:
+             &'r (dyn TypedError<'r> + 'r)
+             &'r rocket::Request<'r>
+             Status
+             std::option::Option<&'r (dyn TypedError<'r> + 'r)>
+   = note: required for `Foo` to implement `FromError<'_>`
+
+error[E0277]: the trait bound `rocket::Request<'_>: FromError<'_>` is not satisfied
+  --> tests/ui-fail-nightly/typed-catchers.rs:30:26
+   |
+30 | fn request_by_value(foo: Request<'_>) -> &'static str {
+   |                          ^^^^^^^^^^^ the trait `FromRequest<'_>` is not implemented for `rocket::Request<'_>`, which is required by `rocket::Request<'_>: FromError<'_>`
+   |
+   = help: the following other types implement trait `FromError<'r>`:
+             &'r (dyn TypedError<'r> + 'r)
+             &'r rocket::Request<'r>
+             Status
+             std::option::Option<&'r (dyn TypedError<'r> + 'r)>
+   = note: required for `rocket::Request<'_>` to implement `FromError<'_>`
+
+warning: unused variable: `foo`
+  --> tests/ui-fail-nightly/typed-catchers.rs:20:27
+   |
+20 | fn doesnt_implement_error(foo: &Foo) -> &'static str {
+   |                           ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
+   |
+   = note: `#[warn(unused_variables)]` on by default
+
+warning: unused variable: `foo`
+  --> tests/ui-fail-nightly/typed-catchers.rs:25:32
+   |
+25 | fn doesnt_implement_from_error(foo: Foo) -> &'static str {
+   |                                ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
+
+warning: unused variable: `foo`
+  --> tests/ui-fail-nightly/typed-catchers.rs:30:21
+   |
+30 | fn request_by_value(foo: Request<'_>) -> &'static str {
+   |                     ^^^ help: if this is intentional, prefix it with an underscore: `_foo`

--- a/core/codegen/tests/ui-fail-nightly/typed_error.rs
+++ b/core/codegen/tests/ui-fail-nightly/typed_error.rs
@@ -1,0 +1,1 @@
+../ui-fail/typed_error.rs

--- a/core/codegen/tests/ui-fail-nightly/typed_error.stderr
+++ b/core/codegen/tests/ui-fail-nightly/typed_error.stderr
@@ -1,0 +1,109 @@
+error: only one lifetime is supported
+ --> tests/ui-fail-nightly/typed_error.rs:8:14
+  |
+8 | struct Thing1<'a, 'b> {
+  |              ^^^^^^^^
+  |
+note: error occurred while deriving `TypedError`
+ --> tests/ui-fail-nightly/typed_error.rs:7:10
+  |
+7 | #[derive(TypedError)]
+  |          ^^^^^^^^^^
+  = note: this error originates in the derive macro `TypedError` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: only one lifetime is supported
+ --> tests/ui-fail-nightly/typed_error.rs:8:14
+  |
+8 | struct Thing1<'a, 'b> {
+  |              ^^^^^^^^
+  |
+note: error occurred while deriving `Transient`
+ --> tests/ui-fail-nightly/typed_error.rs:7:10
+  |
+7 | #[derive(TypedError)]
+  |          ^^^^^^^^^^
+  = note: this error originates in the derive macro `TypedError` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: only one lifetime is supported
+  --> tests/ui-fail-nightly/typed_error.rs:20:12
+   |
+20 | enum Thing3<'a, 'b> {
+   |            ^^^^^^^^
+   |
+note: error occurred while deriving `TypedError`
+  --> tests/ui-fail-nightly/typed_error.rs:19:10
+   |
+19 | #[derive(TypedError)]
+   |          ^^^^^^^^^^
+   = note: this error originates in the derive macro `TypedError` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: only one lifetime is supported
+  --> tests/ui-fail-nightly/typed_error.rs:20:12
+   |
+20 | enum Thing3<'a, 'b> {
+   |            ^^^^^^^^
+   |
+note: error occurred while deriving `Transient`
+  --> tests/ui-fail-nightly/typed_error.rs:19:10
+   |
+19 | #[derive(TypedError)]
+   |          ^^^^^^^^^^
+   = note: this error originates in the derive macro `TypedError` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0601]: `main` function not found in crate `$CRATE`
+  --> tests/ui-fail-nightly/typed_error.rs:32:19
+   |
+32 | enum EmptyEnum { }
+   |                   ^ consider adding a `main` function to `$DIR/tests/ui-fail-nightly/typed_error.rs`
+
+error[E0277]: the trait bound `InnerNonError: TypedError<'r>` is not satisfied
+  --> tests/ui-fail-nightly/typed_error.rs:15:5
+   |
+15 | /     #[error(source)]
+16 | |     inner: InnerNonError,
+   | |________________________^ the trait `TypedError<'r>` is not implemented for `InnerNonError`
+   |
+   = help: the following other types implement trait `TypedError<'r>`:
+             <() as TypedError<'r>>
+             <Accepted<R> as TypedError<'_>>
+             <AnyError<'r> as TypedError<'r>>
+             <BadRequest<R> as TypedError<'_>>
+             <Conflict<R> as TypedError<'_>>
+             <Created<R> as TypedError<'_>>
+             <EmptyEnum as TypedError<'r>>
+             <Errors<'r> as TypedError<'r>>
+           and $N others
+   = note: required for the cast from `&InnerNonError` to `&(dyn TypedError<'r> + 'r)`
+
+error[E0277]: the trait bound `InnerNonError: TypedError<'r>` is not satisfied
+  --> tests/ui-fail-nightly/typed_error.rs:27:7
+   |
+27 |     A(#[error(source)] InnerNonError),
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `TypedError<'r>` is not implemented for `InnerNonError`
+   |
+   = help: the following other types implement trait `TypedError<'r>`:
+             <() as TypedError<'r>>
+             <Accepted<R> as TypedError<'_>>
+             <AnyError<'r> as TypedError<'r>>
+             <BadRequest<R> as TypedError<'_>>
+             <Conflict<R> as TypedError<'_>>
+             <Created<R> as TypedError<'_>>
+             <EmptyEnum as TypedError<'r>>
+             <Errors<'r> as TypedError<'r>>
+           and $N others
+   = note: required for the cast from `&InnerNonError` to `&(dyn TypedError<'r> + 'r)`
+
+error[E0004]: non-exhaustive patterns: type `&EmptyEnum` is non-empty
+  --> tests/ui-fail-nightly/typed_error.rs:31:10
+   |
+31 | #[derive(TypedError)]
+   |          ^^^^^^^^^^
+   |
+note: `EmptyEnum` defined here
+  --> tests/ui-fail-nightly/typed_error.rs:32:6
+   |
+32 | enum EmptyEnum { }
+   |      ^^^^^^^^^
+   = note: the matched value is of type `&EmptyEnum`
+   = note: references are always considered inhabited
+   = note: this error originates in the derive macro `TypedError` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/core/codegen/tests/ui-fail-stable/async-entry.stderr
+++ b/core/codegen/tests/ui-fail-stable/async-entry.stderr
@@ -10,7 +10,7 @@ error: [note] this function must be `async`
  --> tests/ui-fail-stable/async-entry.rs:5:5
   |
 5 |     fn foo() { }
-  |     ^^^^^^^^
+  |     ^^
 
 error: attribute can only be applied to `async` functions
   --> tests/ui-fail-stable/async-entry.rs:16:5
@@ -24,7 +24,7 @@ error: [note] this function must be `async`
   --> tests/ui-fail-stable/async-entry.rs:17:5
    |
 17 |     fn main() {
-   |     ^^^^^^^^^
+   |     ^^
 
 error: attribute cannot be applied to `main` function
        = note: this attribute generates a `main` function
@@ -53,7 +53,7 @@ error: [note] this function must return a value
   --> tests/ui-fail-stable/async-entry.rs:57:5
    |
 57 |     async fn rocket() {
-   |     ^^^^^^^^^^^^^^^^^
+   |     ^^^^^
 
 error: attribute can only be applied to functions that return a value
   --> tests/ui-fail-stable/async-entry.rs:64:5
@@ -67,7 +67,7 @@ error: [note] this function must return a value
   --> tests/ui-fail-stable/async-entry.rs:65:5
    |
 65 |     fn rocket() {
-   |     ^^^^^^^^^^^
+   |     ^^
 
 error: attribute cannot be applied to `main` function
        = note: this attribute generates a `main` function

--- a/core/codegen/tests/ui-fail-stable/bad-ignored-segments.stderr
+++ b/core/codegen/tests/ui-fail-stable/bad-ignored-segments.stderr
@@ -1,13 +1,13 @@
 error: parameter must be named
        = help: use a name such as `_guard` or `_param`
- --> tests/ui-fail-stable/bad-ignored-segments.rs:6:12
+ --> tests/ui-fail-stable/bad-ignored-segments.rs:6:7
   |
 6 | #[get("/c?<_>")]
-  |            ^
+  |       ^^^^^^^^
 
 error: parameter must be named
        = help: use a name such as `_guard` or `_param`
- --> tests/ui-fail-stable/bad-ignored-segments.rs:9:22
+ --> tests/ui-fail-stable/bad-ignored-segments.rs:9:21
   |
 9 | #[post("/d", data = "<_>")]
-  |                      ^^^
+  |                     ^^^^^

--- a/core/codegen/tests/ui-fail-stable/catch.stderr
+++ b/core/codegen/tests/ui-fail-stable/catch.stderr
@@ -24,14 +24,14 @@ error: unexpected keyed parameter: expected literal or identifier
   --> tests/ui-fail-stable/catch.rs:14:9
    |
 14 | #[catch(code = "404")]
-   |         ^^^^^^^^^^^^
+   |         ^^^^
 
 error: unexpected keyed parameter: expected literal or identifier
        = help: `#[catch]` expects a status code int or `default`: `#[catch(404)]` or `#[catch(default)]`
   --> tests/ui-fail-stable/catch.rs:17:9
    |
 17 | #[catch(code = 404)]
-   |         ^^^^^^^^^^
+   |         ^^^^
 
 error: status must be in range [100, 599]
        = help: `#[catch]` expects a status code int or `default`: `#[catch(404)]` or `#[catch(default)]`
@@ -52,22 +52,17 @@ error: unexpected attribute parameter: `message`
   --> tests/ui-fail-stable/catch.rs:26:14
    |
 26 | #[catch(400, message = "foo")]
-   |              ^^^^^^^^^^^^^^^
+   |              ^^^^^^^
 
-error[E0308]: arguments to this function are incorrect
-  --> tests/ui-fail-stable/catch.rs:30:4
+error[E0277]: the trait bound `bool: FromError<'_>` is not satisfied
+  --> tests/ui-fail-stable/catch.rs:30:35
    |
 30 | fn f3(_request: &Request, _other: bool) { }
-   |    ^^           --------          ---- an argument of type `bool` is missing
-   |                 |
-   |                 unexpected argument of type `Status`
+   |                                   ^^^^ the trait `FromRequest<'_>` is not implemented for `bool`, which is required by `bool: FromError<'_>`
    |
-note: function defined here
-  --> tests/ui-fail-stable/catch.rs:30:4
-   |
-30 | fn f3(_request: &Request, _other: bool) { }
-   |    ^^ ------------------  ------------
-help: provide the argument
-   |
-29 | f3(bool, /* bool */)
-   |
+   = help: the following other types implement trait `FromError<'r>`:
+             Status
+             std::option::Option<&'r (dyn TypedError<'r> + 'r)>
+             &'r rocket::Request<'r>
+             &'r (dyn TypedError<'r> + 'r)
+   = note: required for `bool` to implement `FromError<'_>`

--- a/core/codegen/tests/ui-fail-stable/catch_type_errors.stderr
+++ b/core/codegen/tests/ui-fail-stable/catch_type_errors.stderr
@@ -17,6 +17,24 @@ error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied
             <rocket::serde::json::Value as Responder<'r, 'static>>
           and $N others
 
+error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied
+ --> tests/ui-fail-stable/catch_type_errors.rs:5:1
+  |
+5 | #[catch(404)]
+  | ^^^^^^^^^^^^^ the trait `Responder<'_, '_>` is not implemented for `usize`
+  |
+  = help: the following other types implement trait `Responder<'r, 'o>`:
+            <Box<str> as Responder<'r, 'static>>
+            <Box<[u8]> as Responder<'r, 'static>>
+            <Box<T> as Responder<'r, 'o>>
+            <rocket::either::Either<T, E> as Responder<'r, 'o>>
+            <Cow<'o, R> as Responder<'r, 'o>>
+            <rocket::tokio::fs::File as Responder<'r, 'static>>
+            <EventStream<S> as Responder<'r, 'r>>
+            <rocket::serde::json::Value as Responder<'r, 'static>>
+          and $N others
+  = note: this error originates in the attribute macro `catch` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: the trait bound `bool: Responder<'_, '_>` is not satisfied
   --> tests/ui-fail-stable/catch_type_errors.rs:11:30
    |
@@ -36,19 +54,36 @@ error[E0277]: the trait bound `bool: Responder<'_, '_>` is not satisfied
              <rocket::serde::json::Value as Responder<'r, 'static>>
            and $N others
 
-error[E0308]: mismatched types
+error[E0277]: the trait bound `bool: Responder<'_, '_>` is not satisfied
+  --> tests/ui-fail-stable/catch_type_errors.rs:10:1
+   |
+10 | #[catch(404)]
+   | ^^^^^^^^^^^^^ the trait `Responder<'_, '_>` is not implemented for `bool`
+   |
+   = help: the following other types implement trait `Responder<'r, 'o>`:
+             <Box<str> as Responder<'r, 'static>>
+             <Box<[u8]> as Responder<'r, 'static>>
+             <Box<T> as Responder<'r, 'o>>
+             <rocket::either::Either<T, E> as Responder<'r, 'o>>
+             <Cow<'o, R> as Responder<'r, 'o>>
+             <rocket::tokio::fs::File as Responder<'r, 'static>>
+             <EventStream<S> as Responder<'r, 'r>>
+             <rocket::serde::json::Value as Responder<'r, 'static>>
+           and $N others
+   = note: this error originates in the attribute macro `catch` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `bool: FromError<'_>` is not satisfied
   --> tests/ui-fail-stable/catch_type_errors.rs:16:17
    |
 16 | fn f3(_request: bool) -> usize {
-   |    --           ^^^^ expected `bool`, found `&Request<'_>`
-   |    |
-   |    arguments to this function are incorrect
+   |                 ^^^^ the trait `FromRequest<'_>` is not implemented for `bool`, which is required by `bool: FromError<'_>`
    |
-note: function defined here
-  --> tests/ui-fail-stable/catch_type_errors.rs:16:4
-   |
-16 | fn f3(_request: bool) -> usize {
-   |    ^^ --------------
+   = help: the following other types implement trait `FromError<'r>`:
+             Status
+             std::option::Option<&'r (dyn TypedError<'r> + 'r)>
+             &'r rocket::Request<'r>
+             &'r (dyn TypedError<'r> + 'r)
+   = note: required for `bool` to implement `FromError<'_>`
 
 error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied
   --> tests/ui-fail-stable/catch_type_errors.rs:16:26
@@ -70,6 +105,24 @@ error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied
            and $N others
 
 error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied
+  --> tests/ui-fail-stable/catch_type_errors.rs:15:1
+   |
+15 | #[catch(404)]
+   | ^^^^^^^^^^^^^ the trait `Responder<'_, '_>` is not implemented for `usize`
+   |
+   = help: the following other types implement trait `Responder<'r, 'o>`:
+             <Box<str> as Responder<'r, 'static>>
+             <Box<[u8]> as Responder<'r, 'static>>
+             <Box<T> as Responder<'r, 'o>>
+             <rocket::either::Either<T, E> as Responder<'r, 'o>>
+             <Cow<'o, R> as Responder<'r, 'o>>
+             <rocket::tokio::fs::File as Responder<'r, 'static>>
+             <EventStream<S> as Responder<'r, 'r>>
+             <rocket::serde::json::Value as Responder<'r, 'static>>
+           and $N others
+   = note: this error originates in the attribute macro `catch` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied
   --> tests/ui-fail-stable/catch_type_errors.rs:21:12
    |
 20 | #[catch(404)]
@@ -87,3 +140,21 @@ error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied
              <EventStream<S> as Responder<'r, 'r>>
              <rocket::serde::json::Value as Responder<'r, 'static>>
            and $N others
+
+error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied
+  --> tests/ui-fail-stable/catch_type_errors.rs:20:1
+   |
+20 | #[catch(404)]
+   | ^^^^^^^^^^^^^ the trait `Responder<'_, '_>` is not implemented for `usize`
+   |
+   = help: the following other types implement trait `Responder<'r, 'o>`:
+             <Box<str> as Responder<'r, 'static>>
+             <Box<[u8]> as Responder<'r, 'static>>
+             <Box<T> as Responder<'r, 'o>>
+             <rocket::either::Either<T, E> as Responder<'r, 'o>>
+             <Cow<'o, R> as Responder<'r, 'o>>
+             <rocket::tokio::fs::File as Responder<'r, 'static>>
+             <EventStream<S> as Responder<'r, 'r>>
+             <rocket::serde::json::Value as Responder<'r, 'static>>
+           and $N others
+   = note: this error originates in the attribute macro `catch` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/core/codegen/tests/ui-fail-stable/from_form.stderr
+++ b/core/codegen/tests/ui-fail-stable/from_form.stderr
@@ -2,7 +2,7 @@ error: enums are not supported
  --> tests/ui-fail-stable/from_form.rs:4:1
   |
 4 | enum Thing { }
-  | ^^^^^^^^^^^^^^
+  | ^^^^
 
 error: [note] error occurred while deriving `FromForm`
  --> tests/ui-fail-stable/from_form.rs:3:10
@@ -16,7 +16,7 @@ error: at least one field is required
  --> tests/ui-fail-stable/from_form.rs:7:1
   |
 7 | struct Foo1;
-  | ^^^^^^^^^^^^
+  | ^^^^^^
 
 error: [note] error occurred while deriving `FromForm`
  --> tests/ui-fail-stable/from_form.rs:6:10
@@ -93,14 +93,13 @@ error: [help] declared in this field
   --> tests/ui-fail-stable/from_form.rs:36:5
    |
 36 |     foo: usize,
-   |     ^^^^^^^^^^
+   |     ^^^
 
 error: [note] previous field with conflicting name
   --> tests/ui-fail-stable/from_form.rs:34:5
    |
-34 | /     #[field(name = "foo")]
-35 | |     field: String,
-   | |_________________^
+34 |     #[field(name = "foo")]
+   |     ^
 
 error: [note] error occurred while deriving `FromForm`
   --> tests/ui-fail-stable/from_form.rs:32:10
@@ -119,16 +118,14 @@ error: field name conflicts with previous name
 error: [help] declared in this field
   --> tests/ui-fail-stable/from_form.rs:43:5
    |
-43 | /     #[field(name = "hello")]
-44 | |     other: String,
-   | |_________________^
+43 |     #[field(name = "hello")]
+   |     ^
 
 error: [note] previous field with conflicting name
   --> tests/ui-fail-stable/from_form.rs:41:5
    |
-41 | /     #[field(name = "hello")]
-42 | |     first: String,
-   | |_________________^
+41 |     #[field(name = "hello")]
+   |     ^
 
 error: [note] error occurred while deriving `FromForm`
   --> tests/ui-fail-stable/from_form.rs:39:10
@@ -147,15 +144,14 @@ error: field name conflicts with previous name
 error: [help] declared in this field
   --> tests/ui-fail-stable/from_form.rs:50:5
    |
-50 | /     #[field(name = "first")]
-51 | |     other: String,
-   | |_________________^
+50 |     #[field(name = "first")]
+   |     ^
 
 error: [note] previous field with conflicting name
   --> tests/ui-fail-stable/from_form.rs:49:5
    |
 49 |     first: String,
-   |     ^^^^^^^^^^^^^
+   |     ^^^^^
 
 error: [note] error occurred while deriving `FromForm`
   --> tests/ui-fail-stable/from_form.rs:47:10
@@ -169,7 +165,7 @@ error: unexpected attribute parameter: `field`
   --> tests/ui-fail-stable/from_form.rs:56:28
    |
 56 |     #[field(name = "blah", field = "bloo")]
-   |                            ^^^^^^^^^^^^^^
+   |                            ^^^^^
 
 error: [note] error occurred while deriving `FromForm`
   --> tests/ui-fail-stable/from_form.rs:54:10
@@ -225,7 +221,7 @@ error: unexpected attribute parameter: `beep`
   --> tests/ui-fail-stable/from_form.rs:80:13
    |
 80 |     #[field(beep = "bop")]
-   |             ^^^^^^^^^^^^
+   |             ^^^^
 
 error: [note] error occurred while deriving `FromForm`
   --> tests/ui-fail-stable/from_form.rs:78:10
@@ -238,10 +234,8 @@ error: [note] error occurred while deriving `FromForm`
 error: field has conflicting names
   --> tests/ui-fail-stable/from_form.rs:86:5
    |
-86 | /     #[field(name = "blah")]
-87 | |     #[field(name = "blah")]
-88 | |     my_field: String,
-   | |____________________^
+86 |     #[field(name = "blah")]
+   |     ^
 
 error: [note] this field name...
   --> tests/ui-fail-stable/from_form.rs:86:20
@@ -399,7 +393,7 @@ error: duplicate attribute parameter: default
    --> tests/ui-fail-stable/from_form.rs:177:26
     |
 177 |     #[field(default = 1, default = 2)]
-    |                          ^^^^^^^^^^^
+    |                          ^^^^^^^
 
 error: [note] error occurred while deriving `FromForm`
    --> tests/ui-fail-stable/from_form.rs:175:10

--- a/core/codegen/tests/ui-fail-stable/from_form_field.stderr
+++ b/core/codegen/tests/ui-fail-stable/from_form_field.stderr
@@ -2,7 +2,7 @@ error: tuple structs are not supported
  --> tests/ui-fail-stable/from_form_field.rs:4:1
   |
 4 | struct Foo1;
-  | ^^^^^^^^^^^^
+  | ^^^^^^
 
 error: [note] error occurred while deriving `FromFormField`
  --> tests/ui-fail-stable/from_form_field.rs:3:10
@@ -16,7 +16,7 @@ error: tuple structs are not supported
  --> tests/ui-fail-stable/from_form_field.rs:7:1
   |
 7 | struct Foo2(usize);
-  | ^^^^^^^^^^^^^^^^^^^
+  | ^^^^^^
 
 error: [note] error occurred while deriving `FromFormField`
  --> tests/ui-fail-stable/from_form_field.rs:6:10
@@ -29,10 +29,8 @@ error: [note] error occurred while deriving `FromFormField`
 error: named structs are not supported
   --> tests/ui-fail-stable/from_form_field.rs:10:1
    |
-10 | / struct Foo3 {
-11 | |     foo: usize,
-12 | | }
-   | |_^
+10 | struct Foo3 {
+   | ^^^^^^
 
 error: [note] error occurred while deriving `FromFormField`
  --> tests/ui-fail-stable/from_form_field.rs:9:10
@@ -60,7 +58,7 @@ error: enum must have at least one variant
   --> tests/ui-fail-stable/from_form_field.rs:20:1
    |
 20 | enum Foo5 { }
-   | ^^^^^^^^^^^^^
+   | ^^^^
 
 error: [note] error occurred while deriving `FromFormField`
   --> tests/ui-fail-stable/from_form_field.rs:19:10
@@ -115,10 +113,8 @@ error: [note] error occurred while deriving `FromFormField`
 error: variant has conflicting values
   --> tests/ui-fail-stable/from_form_field.rs:41:5
    |
-41 | /     #[field(value = "bar")]
-42 | |     #[field(value = "bar")]
-43 | |     A,
-   | |_____^
+41 |     #[field(value = "bar")]
+   |     ^
 
 error: [note] this value...
   --> tests/ui-fail-stable/from_form_field.rs:41:21
@@ -149,16 +145,14 @@ error: field value conflicts with previous value
 error: [help] ...declared in this variant
   --> tests/ui-fail-stable/from_form_field.rs:50:5
    |
-50 | /     #[field(value = "BAr")]
-51 | |     B,
-   | |_____^
+50 |     #[field(value = "BAr")]
+   |     ^
 
 error: [note] previous field with conflicting name
   --> tests/ui-fail-stable/from_form_field.rs:48:5
    |
-48 | /     #[field(value = "bar")]
-49 | |     A,
-   | |_____^
+48 |     #[field(value = "bar")]
+   |     ^
 
 error: [note] error occurred while deriving `FromFormField`
   --> tests/ui-fail-stable/from_form_field.rs:46:10
@@ -177,9 +171,8 @@ error: field value conflicts with previous value
 error: [help] ...declared in this variant
   --> tests/ui-fail-stable/from_form_field.rs:57:5
    |
-57 | /     #[field(value = "a")]
-58 | |     B,
-   | |_____^
+57 |     #[field(value = "a")]
+   |     ^
 
 error: [note] previous field with conflicting name
   --> tests/ui-fail-stable/from_form_field.rs:56:5
@@ -198,10 +191,8 @@ error: [note] error occurred while deriving `FromFormField`
 error: variant has conflicting values
   --> tests/ui-fail-stable/from_form_field.rs:80:5
    |
-80 | /     #[field(value = "FoO")]
-81 | |     #[field(value = "foo")]
-82 | |     A,
-   | |_____^
+80 |     #[field(value = "FoO")]
+   |     ^
 
 error: [note] this value...
   --> tests/ui-fail-stable/from_form_field.rs:80:21
@@ -226,10 +217,8 @@ error: [note] error occurred while deriving `FromFormField`
 error: field has conflicting names
   --> tests/ui-fail-stable/from_form_field.rs:87:5
    |
-87 | /     #[field(name = "foo")]
-88 | |     #[field(name = uncased("FOO"))]
-89 | |     single: usize,
-   | |_________________^
+87 |     #[field(name = "foo")]
+   |     ^
 
 error: [note] this field name...
   --> tests/ui-fail-stable/from_form_field.rs:87:20
@@ -260,16 +249,14 @@ error: field name conflicts with previous name
 error: [help] declared in this field
   --> tests/ui-fail-stable/from_form_field.rs:96:5
    |
-96 | /     #[field(name = "foo")]
-97 | |     other: usize,
-   | |________________^
+96 |     #[field(name = "foo")]
+   |     ^
 
 error: [note] previous field with conflicting name
   --> tests/ui-fail-stable/from_form_field.rs:94:5
    |
-94 | /     #[field(name = "foo")]
-95 | |     single: usize,
-   | |_________________^
+94 |     #[field(name = "foo")]
+   |     ^
 
 error: [note] error occurred while deriving `FromForm`
   --> tests/ui-fail-stable/from_form_field.rs:92:10
@@ -289,14 +276,13 @@ error: [help] declared in this field
    --> tests/ui-fail-stable/from_form_field.rs:104:5
     |
 104 |     hello_there: usize,
-    |     ^^^^^^^^^^^^^^^^^^
+    |     ^^^^^^^^^^^
 
 error: [note] previous field with conflicting name
    --> tests/ui-fail-stable/from_form_field.rs:102:5
     |
-102 | /     #[field(name = uncased("HELLO_THERE"))]
-103 | |     single: usize,
-    | |_________________^
+102 |     #[field(name = uncased("HELLO_THERE"))]
+    |     ^
 
 error: [note] error occurred while deriving `FromForm`
    --> tests/ui-fail-stable/from_form_field.rs:100:10
@@ -316,14 +302,13 @@ error: [help] declared in this field
    --> tests/ui-fail-stable/from_form_field.rs:111:5
     |
 111 |     hello_there: usize,
-    |     ^^^^^^^^^^^^^^^^^^
+    |     ^^^^^^^^^^^
 
 error: [note] previous field with conflicting name
    --> tests/ui-fail-stable/from_form_field.rs:109:5
     |
-109 | /     #[field(name = "hello_there")]
-110 | |     single: usize,
-    | |_________________^
+109 |     #[field(name = "hello_there")]
+    |     ^
 
 error: [note] error occurred while deriving `FromForm`
    --> tests/ui-fail-stable/from_form_field.rs:107:10

--- a/core/codegen/tests/ui-fail-stable/from_form_type_errors.stderr
+++ b/core/codegen/tests/ui-fail-stable/from_form_type_errors.stderr
@@ -56,7 +56,7 @@ error[E0277]: the trait bound `Foo<usize>: FromFormField<'_>` is not satisfied
   --> tests/ui-fail-stable/from_form_type_errors.rs:14:12
    |
 14 |     field: Foo<usize>,
-   |            ^^^^^^^^^^ the trait `FromFormField<'_>` is not implemented for `Foo<usize>`, which is required by `Foo<usize>: FromForm<'r>`
+   |            ^^^ the trait `FromFormField<'_>` is not implemented for `Foo<usize>`, which is required by `Foo<usize>: FromForm<'r>`
    |
    = help: the following other types implement trait `FromFormField<'v>`:
              bool
@@ -209,7 +209,7 @@ error[E0277]: the trait bound `Foo<usize>: FromFormField<'_>` is not satisfied
    |          -------- in this derive macro expansion
 13 | struct Other {
 14 |     field: Foo<usize>,
-   |            ^^^^^^^^^^ the trait `FromFormField<'_>` is not implemented for `Foo<usize>`, which is required by `Foo<usize>: FromForm<'r>`
+   |            ^^^ the trait `FromFormField<'_>` is not implemented for `Foo<usize>`, which is required by `Foo<usize>: FromForm<'r>`
    |
    = help: the following other types implement trait `FromFormField<'v>`:
              bool

--- a/core/codegen/tests/ui-fail-stable/responder-types.stderr
+++ b/core/codegen/tests/ui-fail-stable/responder-types.stderr
@@ -1,3 +1,39 @@
+error[E0277]: the trait bound `u8: Responder<'r, 'static>` is not satisfied
+ --> tests/ui-fail-stable/responder-types.rs:3:10
+  |
+3 | #[derive(Responder)]
+  |          ^^^^^^^^^ the trait `Responder<'r, 'static>` is not implemented for `u8`
+  |
+  = help: the following other types implement trait `Responder<'r, 'o>`:
+            <Thing1 as Responder<'r, 'o>>
+            <Thing2 as Responder<'r, 'o>>
+            <Thing3 as Responder<'r, 'o>>
+            <Thing4 as Responder<'r, 'o>>
+            <Box<str> as Responder<'r, 'static>>
+            <Box<[u8]> as Responder<'r, 'static>>
+            <Box<T> as Responder<'r, 'o>>
+            <rocket::either::Either<T, E> as Responder<'r, 'o>>
+          and $N others
+  = note: this error originates in the derive macro `Responder` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `u8: Responder<'r, 'static>` is not satisfied
+  --> tests/ui-fail-stable/responder-types.rs:14:10
+   |
+14 | #[derive(Responder)]
+   |          ^^^^^^^^^ the trait `Responder<'r, 'static>` is not implemented for `u8`
+   |
+   = help: the following other types implement trait `Responder<'r, 'o>`:
+             <Thing1 as Responder<'r, 'o>>
+             <Thing2 as Responder<'r, 'o>>
+             <Thing3 as Responder<'r, 'o>>
+             <Thing4 as Responder<'r, 'o>>
+             <Box<str> as Responder<'r, 'static>>
+             <Box<[u8]> as Responder<'r, 'static>>
+             <Box<T> as Responder<'r, 'o>>
+             <rocket::either::Either<T, E> as Responder<'r, 'o>>
+           and $N others
+   = note: this error originates in the derive macro `Responder` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: the trait bound `u8: Responder<'_, '_>` is not satisfied
  --> tests/ui-fail-stable/responder-types.rs:5:12
   |
@@ -15,11 +51,28 @@ error[E0277]: the trait bound `u8: Responder<'_, '_>` is not satisfied
             <rocket::either::Either<T, E> as Responder<'r, 'o>>
           and $N others
 
+error[E0277]: the trait bound `u8: Responder<'_, '_>` is not satisfied
+ --> tests/ui-fail-stable/responder-types.rs:5:5
+  |
+5 |     thing: u8,
+  |     ^^^^^ the trait `Responder<'_, '_>` is not implemented for `u8`
+  |
+  = help: the following other types implement trait `Responder<'r, 'o>`:
+            <Thing1 as Responder<'r, 'o>>
+            <Thing2 as Responder<'r, 'o>>
+            <Thing3 as Responder<'r, 'o>>
+            <Thing4 as Responder<'r, 'o>>
+            <Box<str> as Responder<'r, 'static>>
+            <Box<[u8]> as Responder<'r, 'static>>
+            <Box<T> as Responder<'r, 'o>>
+            <rocket::either::Either<T, E> as Responder<'r, 'o>>
+          and $N others
+
 error[E0277]: the trait bound `Header<'_>: From<u8>` is not satisfied
   --> tests/ui-fail-stable/responder-types.rs:11:5
    |
 11 |     other: u8,
-   |     ^^^^^^^^^ the trait `From<u8>` is not implemented for `Header<'_>`, which is required by `u8: Into<Header<'_>>`
+   |     ^^^^^ the trait `From<u8>` is not implemented for `Header<'_>`, which is required by `u8: Into<Header<'_>>`
    |
    = help: the following other types implement trait `From<T>`:
              <Header<'static> as From<Cookie<'_>>>
@@ -59,7 +112,7 @@ error[E0277]: the trait bound `Header<'_>: From<u8>` is not satisfied
   --> tests/ui-fail-stable/responder-types.rs:17:5
    |
 17 |     other: u8,
-   |     ^^^^^^^^^ the trait `From<u8>` is not implemented for `Header<'_>`, which is required by `u8: Into<Header<'_>>`
+   |     ^^^^^ the trait `From<u8>` is not implemented for `Header<'_>`, which is required by `u8: Into<Header<'_>>`
    |
    = help: the following other types implement trait `From<T>`:
              <Header<'static> as From<Cookie<'_>>>
@@ -78,11 +131,28 @@ note: required by a bound in `Response::<'r>::set_header`
    |     pub fn set_header<'h: 'r, H: Into<Header<'h>>>(&mut self, header: H) -> bool {
    |                                  ^^^^^^^^^^^^^^^^ required by this bound in `Response::<'r>::set_header`
 
+error[E0277]: the trait bound `u8: Responder<'_, '_>` is not satisfied
+  --> tests/ui-fail-stable/responder-types.rs:16:5
+   |
+16 |     thing: u8,
+   |     ^^^^^ the trait `Responder<'_, '_>` is not implemented for `u8`
+   |
+   = help: the following other types implement trait `Responder<'r, 'o>`:
+             <Thing1 as Responder<'r, 'o>>
+             <Thing2 as Responder<'r, 'o>>
+             <Thing3 as Responder<'r, 'o>>
+             <Thing4 as Responder<'r, 'o>>
+             <Box<str> as Responder<'r, 'static>>
+             <Box<[u8]> as Responder<'r, 'static>>
+             <Box<T> as Responder<'r, 'o>>
+             <rocket::either::Either<T, E> as Responder<'r, 'o>>
+           and $N others
+
 error[E0277]: the trait bound `Header<'_>: From<std::string::String>` is not satisfied
   --> tests/ui-fail-stable/responder-types.rs:24:5
    |
 24 |     then: String,
-   |     ^^^^^^^^^^^^ the trait `From<std::string::String>` is not implemented for `Header<'_>`, which is required by `std::string::String: Into<Header<'_>>`
+   |     ^^^^ the trait `From<std::string::String>` is not implemented for `Header<'_>`, which is required by `std::string::String: Into<Header<'_>>`
    |
    = help: the following other types implement trait `From<T>`:
              <Header<'static> as From<Cookie<'_>>>
@@ -119,9 +189,9 @@ error[E0277]: the trait bound `usize: Responder<'_, '_>` is not satisfied
              <Box<T> as Responder<'r, 'o>>
              <rocket::either::Either<T, E> as Responder<'r, 'o>>
            and $N others
-note: required by a bound in `route::handler::<impl Outcome<Response<'o>, Status, (rocket::Data<'o>, Status)>>::from`
+note: required by a bound in `route::handler::<impl Outcome<Response<'o>, (Status, std::option::Option<Box<(dyn TypedError<'o> + 'o)>>), (rocket::Data<'o>, Status, std::option::Option<Box<(dyn TypedError<'o> + 'o)>>)>>::from`
   --> $WORKSPACE/core/lib/src/route/handler.rs
    |
    |     pub fn from<R: Responder<'r, 'o>>(req: &'r Request<'_>, responder: R) -> Outcome<'r> {
-   |                    ^^^^^^^^^^^^^^^^^ required by this bound in `route::handler::<impl Outcome<Response<'o>, Status, (Data<'o>, Status)>>::from`
+   |                    ^^^^^^^^^^^^^^^^^ required by this bound in `route::handler::<impl Outcome<Response<'o>, (Status, Option<Box<dyn TypedError<'o>>>), (Data<'o>, Status, Option<Box<dyn TypedError<'o>>>)>>::from`
    = note: this error originates in the attribute macro `get` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/core/codegen/tests/ui-fail-stable/responder.stderr
+++ b/core/codegen/tests/ui-fail-stable/responder.stderr
@@ -2,7 +2,7 @@ error: need at least one field
  --> tests/ui-fail-stable/responder.rs:4:1
   |
 4 | struct Thing1;
-  | ^^^^^^^^^^^^^^
+  | ^^^^^^
 
 error: [note] error occurred while deriving `Responder`
  --> tests/ui-fail-stable/responder.rs:3:10
@@ -44,7 +44,7 @@ error: only one lifetime is supported
   --> tests/ui-fail-stable/responder.rs:16:14
    |
 16 | struct Thing4<'a, 'b>(&'a str, &'b str);
-   |              ^^^^^^^^
+   |              ^
 
 error: [note] error occurred while deriving `Responder`
   --> tests/ui-fail-stable/responder.rs:15:10

--- a/core/codegen/tests/ui-fail-stable/route-attribute-general-syntax.stderr
+++ b/core/codegen/tests/ui-fail-stable/route-attribute-general-syntax.stderr
@@ -50,26 +50,26 @@ error: unexpected keyed parameter: expected literal or identifier
   --> tests/ui-fail-stable/route-attribute-general-syntax.rs:27:7
    |
 27 | #[get(data = "<foo>", "/")]
-   |       ^^^^^^^^^^^^^^
+   |       ^^^^
 
 error: unexpected attribute parameter: `unknown`
   --> tests/ui-fail-stable/route-attribute-general-syntax.rs:30:12
    |
 30 | #[get("/", unknown = "foo")]
-   |            ^^^^^^^^^^^^^^^
+   |            ^^^^^^^
 
 error: expected key/value `key = value`
   --> tests/ui-fail-stable/route-attribute-general-syntax.rs:33:12
    |
 33 | #[get("/", ...)]
-   |            ^^^
+   |            ^
 
 error: handler arguments must be named
        = help: to name an ignored handler argument, use `_name`
   --> tests/ui-fail-stable/route-attribute-general-syntax.rs:39:7
    |
 39 | fn c1(_: usize) {}
-   |       ^^^^^^^^
+   |       ^
 
 error: invalid value: expected string literal
   --> tests/ui-fail-stable/route-attribute-general-syntax.rs:43:7

--- a/core/codegen/tests/ui-fail-stable/route-path-bad-syntax.stderr
+++ b/core/codegen/tests/ui-fail-stable/route-path-bad-syntax.stderr
@@ -1,57 +1,57 @@
 error: invalid route URI: expected token '/' but found 'a' at index 0
        = help: expected URI in origin form: "/path/<param>"
- --> tests/ui-fail-stable/route-path-bad-syntax.rs:5:8
+ --> tests/ui-fail-stable/route-path-bad-syntax.rs:5:7
   |
 5 | #[get("a")]
-  |        ^
+  |       ^^^
 
 error: invalid route URI: unexpected EOF: expected token '/' at index 0
        = help: expected URI in origin form: "/path/<param>"
- --> tests/ui-fail-stable/route-path-bad-syntax.rs:8:8
+ --> tests/ui-fail-stable/route-path-bad-syntax.rs:8:7
   |
 8 | #[get("")]
-  |        ^
+  |       ^^
 
 error: invalid route URI: expected token '/' but found 'a' at index 0
        = help: expected URI in origin form: "/path/<param>"
-  --> tests/ui-fail-stable/route-path-bad-syntax.rs:11:8
+  --> tests/ui-fail-stable/route-path-bad-syntax.rs:11:7
    |
 11 | #[get("a/b/c")]
-   |        ^
+   |       ^^^^^^^
 
 error: route URIs cannot contain empty segments
        = note: expected "/a/b", found "/a///b"
-  --> tests/ui-fail-stable/route-path-bad-syntax.rs:14:10
+  --> tests/ui-fail-stable/route-path-bad-syntax.rs:14:7
    |
 14 | #[get("/a///b")]
-   |          ^^
+   |       ^^^^^^^^
 
 error: route URIs cannot contain empty segments
        = note: expected "/?bat", found "/?bat&&"
-  --> tests/ui-fail-stable/route-path-bad-syntax.rs:17:13
+  --> tests/ui-fail-stable/route-path-bad-syntax.rs:17:7
    |
 17 | #[get("/?bat&&")]
-   |             ^^
+   |       ^^^^^^^^^
 
 error: route URIs cannot contain empty segments
        = note: expected "/?bat", found "/?bat&&"
-  --> tests/ui-fail-stable/route-path-bad-syntax.rs:20:13
+  --> tests/ui-fail-stable/route-path-bad-syntax.rs:20:7
    |
 20 | #[get("/?bat&&")]
-   |             ^^
+   |       ^^^^^^^^^
 
 error: route URIs cannot contain empty segments
        = note: expected "/a/b/", found "/a/b//"
-  --> tests/ui-fail-stable/route-path-bad-syntax.rs:23:12
+  --> tests/ui-fail-stable/route-path-bad-syntax.rs:23:7
    |
 23 | #[get("/a/b//")]
-   |            ^^
+   |       ^^^^^^^^
 
 error: unused parameter
-  --> tests/ui-fail-stable/route-path-bad-syntax.rs:42:10
+  --> tests/ui-fail-stable/route-path-bad-syntax.rs:42:7
    |
 42 | #[get("/<name>")]
-   |          ^^^^
+   |       ^^^^^^^^^
 
 error: [note] expected argument named `name` here
   --> tests/ui-fail-stable/route-path-bad-syntax.rs:43:6
@@ -60,10 +60,10 @@ error: [note] expected argument named `name` here
    |      ^^^^^^^^^^^^^^
 
 error: unused parameter
-  --> tests/ui-fail-stable/route-path-bad-syntax.rs:45:12
+  --> tests/ui-fail-stable/route-path-bad-syntax.rs:45:7
    |
 45 | #[get("/a?<r>")]
-   |            ^
+   |       ^^^^^^^^
 
 error: [note] expected argument named `r` here
   --> tests/ui-fail-stable/route-path-bad-syntax.rs:46:6
@@ -72,10 +72,10 @@ error: [note] expected argument named `r` here
    |      ^^
 
 error: unused parameter
-  --> tests/ui-fail-stable/route-path-bad-syntax.rs:48:23
+  --> tests/ui-fail-stable/route-path-bad-syntax.rs:48:21
    |
 48 | #[post("/a", data = "<test>")]
-   |                       ^^^^
+   |                     ^^^^^^^^
 
 error: [note] expected argument named `test` here
   --> tests/ui-fail-stable/route-path-bad-syntax.rs:49:6
@@ -84,10 +84,10 @@ error: [note] expected argument named `test` here
    |      ^^
 
 error: unused parameter
-  --> tests/ui-fail-stable/route-path-bad-syntax.rs:51:10
+  --> tests/ui-fail-stable/route-path-bad-syntax.rs:51:7
    |
 51 | #[get("/<_r>")]
-   |          ^^
+   |       ^^^^^^^
 
 error: [note] expected argument named `_r` here
   --> tests/ui-fail-stable/route-path-bad-syntax.rs:52:6
@@ -96,10 +96,10 @@ error: [note] expected argument named `_r` here
    |      ^^
 
 error: unused parameter
-  --> tests/ui-fail-stable/route-path-bad-syntax.rs:54:15
+  --> tests/ui-fail-stable/route-path-bad-syntax.rs:54:7
    |
 54 | #[get("/<_r>/<b>")]
-   |               ^
+   |       ^^^^^^^^^^^
 
 error: [note] expected argument named `b` here
   --> tests/ui-fail-stable/route-path-bad-syntax.rs:55:6
@@ -110,73 +110,73 @@ error: [note] expected argument named `b` here
 error: invalid identifier: `foo_.`
        = help: dynamic parameters must be valid identifiers
        = help: did you mean `<foo_>`?
-  --> tests/ui-fail-stable/route-path-bad-syntax.rs:60:10
+  --> tests/ui-fail-stable/route-path-bad-syntax.rs:60:7
    |
 60 | #[get("/<foo_.>")]
-   |          ^^^^^
+   |       ^^^^^^^^^^
 
 error: invalid identifier: `foo*`
        = help: dynamic parameters must be valid identifiers
        = help: did you mean `<foo>`?
-  --> tests/ui-fail-stable/route-path-bad-syntax.rs:63:10
+  --> tests/ui-fail-stable/route-path-bad-syntax.rs:63:7
    |
 63 | #[get("/<foo*>")]
-   |          ^^^^
+   |       ^^^^^^^^^
 
 error: invalid identifier: `!`
        = help: dynamic parameters must be valid identifiers
        = help: did you mean `<param>`?
-  --> tests/ui-fail-stable/route-path-bad-syntax.rs:66:10
+  --> tests/ui-fail-stable/route-path-bad-syntax.rs:66:7
    |
 66 | #[get("/<!>")]
-   |          ^
+   |       ^^^^^^
 
 error: invalid identifier: `name>:<id`
        = help: dynamic parameters must be valid identifiers
        = help: did you mean `<nameid>`?
-  --> tests/ui-fail-stable/route-path-bad-syntax.rs:69:10
+  --> tests/ui-fail-stable/route-path-bad-syntax.rs:69:7
    |
 69 | #[get("/<name>:<id>")]
-   |          ^^^^^^^^^
+   |       ^^^^^^^^^^^^^^
 
 error: unexpected static parameter
        = help: parameter must be dynamic: `<foo>`
-  --> tests/ui-fail-stable/route-path-bad-syntax.rs:74:20
+  --> tests/ui-fail-stable/route-path-bad-syntax.rs:74:19
    |
 74 | #[get("/", data = "foo")]
-   |                    ^^^
+   |                   ^^^^^
 
 error: parameter cannot be trailing
        = help: did you mean `<foo>`?
-  --> tests/ui-fail-stable/route-path-bad-syntax.rs:77:20
+  --> tests/ui-fail-stable/route-path-bad-syntax.rs:77:19
    |
 77 | #[get("/", data = "<foo..>")]
-   |                    ^^^^^^^
+   |                   ^^^^^^^^^
 
 error: unexpected static parameter
        = help: parameter must be dynamic: `<foo>`
-  --> tests/ui-fail-stable/route-path-bad-syntax.rs:80:20
+  --> tests/ui-fail-stable/route-path-bad-syntax.rs:80:19
    |
 80 | #[get("/", data = "<foo")]
-   |                    ^^^^
+   |                   ^^^^^^
 
 error: invalid identifier: `test `
        = help: dynamic parameters must be valid identifiers
        = help: did you mean `<test>`?
-  --> tests/ui-fail-stable/route-path-bad-syntax.rs:83:21
+  --> tests/ui-fail-stable/route-path-bad-syntax.rs:83:19
    |
 83 | #[get("/", data = "<test >")]
-   |                     ^^^^^
+   |                   ^^^^^^^^^
 
 error: handler arguments must be named
        = help: to name an ignored handler argument, use `_name`
   --> tests/ui-fail-stable/route-path-bad-syntax.rs:89:7
    |
 89 | fn k0(_: usize) {}
-   |       ^^^^^^^^
+   |       ^
 
 error: parameters cannot be empty
-  --> tests/ui-fail-stable/route-path-bad-syntax.rs:93:9
+  --> tests/ui-fail-stable/route-path-bad-syntax.rs:93:7
    |
 93 | #[get("/<>")]
-   |         ^^
+   |       ^^^^^

--- a/core/codegen/tests/ui-fail-stable/typed-catchers.rs
+++ b/core/codegen/tests/ui-fail-stable/typed-catchers.rs
@@ -1,0 +1,1 @@
+../ui-fail/typed-catchers.rs

--- a/core/codegen/tests/ui-fail-stable/typed-catchers.stderr
+++ b/core/codegen/tests/ui-fail-stable/typed-catchers.stderr
@@ -1,0 +1,160 @@
+error: invalid type
+ --> tests/ui-fail-stable/typed-catchers.rs:7:26
+  |
+7 | #[catch(default, error = "<foo>")]
+  |                          ^^^^^^^
+
+error: [note] Error argument must be a reference, found `std :: io :: Error`
+       = help: Perhaps use `&std :: io :: Error` instead
+ --> tests/ui-fail-stable/typed-catchers.rs:8:18
+  |
+8 | fn isnt_ref(foo: std::io::Error) -> &'static str {
+  |                  ^^^
+
+error: invalid type
+  --> tests/ui-fail-stable/typed-catchers.rs:12:26
+   |
+12 | #[catch(default, error = "<foo>")]
+   |                          ^^^^^^^
+
+error: [note] Error argument must be a reference, found `Foo`
+       = help: Perhaps use `&Foo` instead
+  --> tests/ui-fail-stable/typed-catchers.rs:13:27
+   |
+13 | fn isnt_ref_or_error(foo: Foo) -> &'static str {
+   |                           ^^^
+
+error[E0277]: the trait bound `Foo: TypedError<'_>` is not satisfied
+  --> tests/ui-fail-stable/typed-catchers.rs:19:1
+   |
+19 | #[catch(default, error = "<foo>")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `TypedError<'_>` is not implemented for `Foo`
+   |
+   = help: the following other types implement trait `TypedError<'r>`:
+             <rocket::either::Either<L, R> as TypedError<'r>>
+             <rocket::serde::json::serde_json::Error as TypedError<'r>>
+             <rocket::serde::msgpack::Error as TypedError<'r>>
+             <rmp_serde::encode::Error as TypedError<'r>>
+             <std::io::Error as TypedError<'r>>
+             <Status as TypedError<'_>>
+             <RequestErrors<'r> as TypedError<'r>>
+             <FromUtf8Error as TypedError<'r>>
+           and $N others
+note: required by a bound in `type_id_of`
+  --> $WORKSPACE/core/lib/src/catcher/types.rs
+   |
+   | pub fn type_id_of<'r, T: TypedError<'r> + Transient + 'r>() -> (TypeId, &'static str) {
+   |                          ^^^^^^^^^^^^^^ required by this bound in `type_id_of`
+   = note: this error originates in the attribute macro `catch` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Foo: Transient` is not satisfied
+  --> tests/ui-fail-stable/typed-catchers.rs:19:1
+   |
+19 | #[catch(default, error = "<foo>")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `rocket::catcher::Static` is not implemented for `Foo`, which is required by `Foo: Transient`
+   |
+   = help: the following other types implement trait `Transient`:
+             Box<[T]>
+             rocket::either::Either<L, R>
+             Inv<'a>
+             transient::transience::Co<'a>
+             transient::transience::Contra<'a>
+             HashMap<K, V>
+             Cow<'a, T>
+             PhantomData<T>
+           and $N others
+   = note: required for `Foo` to implement `Transient`
+note: required by a bound in `type_id_of`
+  --> $WORKSPACE/core/lib/src/catcher/types.rs
+   |
+   | pub fn type_id_of<'r, T: TypedError<'r> + Transient + 'r>() -> (TypeId, &'static str) {
+   |                                           ^^^^^^^^^ required by this bound in `type_id_of`
+   = note: this error originates in the attribute macro `catch` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Foo: TypedError<'_>` is not satisfied
+  --> tests/ui-fail-stable/typed-catchers.rs:19:1
+   |
+19 | #[catch(default, error = "<foo>")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `TypedError<'_>` is not implemented for `Foo`
+   |
+   = help: the following other types implement trait `TypedError<'r>`:
+             <rocket::either::Either<L, R> as TypedError<'r>>
+             <rocket::serde::json::serde_json::Error as TypedError<'r>>
+             <rocket::serde::msgpack::Error as TypedError<'r>>
+             <rmp_serde::encode::Error as TypedError<'r>>
+             <std::io::Error as TypedError<'r>>
+             <Status as TypedError<'_>>
+             <RequestErrors<'r> as TypedError<'r>>
+             <FromUtf8Error as TypedError<'r>>
+           and $N others
+note: required by a bound in `downcast`
+  --> $WORKSPACE/core/lib/src/catcher/types.rs
+   |
+   | pub fn downcast<'r, T: TypedError<'r> + Transient + 'r>(v: Option<&'r dyn TypedError<'r>>) -> Option<&'r T>
+   |                        ^^^^^^^^^^^^^^ required by this bound in `downcast`
+   = note: this error originates in the attribute macro `catch` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Foo: rocket::catcher::Static` is not satisfied
+  --> tests/ui-fail-stable/typed-catchers.rs:19:1
+   |
+19 | #[catch(default, error = "<foo>")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `rocket::catcher::Static` is not implemented for `Foo`, which is required by `Foo: Transient`
+   |
+   = help: the following other types implement trait `rocket::catcher::Static`:
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+             usize
+             u8
+           and $N others
+   = note: required for `Foo` to implement `Transient`
+   = note: this error originates in the attribute macro `catch` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Foo: FromError<'_>` is not satisfied
+  --> tests/ui-fail-stable/typed-catchers.rs:25:37
+   |
+25 | fn doesnt_implement_from_error(foo: Foo) -> &'static str {
+   |                                     ^^^ the trait `FromRequest<'_>` is not implemented for `Foo`, which is required by `Foo: FromError<'_>`
+   |
+   = help: the following other types implement trait `FromError<'r>`:
+             Status
+             std::option::Option<&'r (dyn TypedError<'r> + 'r)>
+             &'r rocket::Request<'r>
+             &'r (dyn TypedError<'r> + 'r)
+   = note: required for `Foo` to implement `FromError<'_>`
+
+error[E0277]: the trait bound `rocket::Request<'_>: FromError<'_>` is not satisfied
+  --> tests/ui-fail-stable/typed-catchers.rs:30:26
+   |
+30 | fn request_by_value(foo: Request<'_>) -> &'static str {
+   |                          ^^^^^^^^^^^ the trait `FromRequest<'_>` is not implemented for `rocket::Request<'_>`, which is required by `rocket::Request<'_>: FromError<'_>`
+   |
+   = help: the following other types implement trait `FromError<'r>`:
+             Status
+             std::option::Option<&'r (dyn TypedError<'r> + 'r)>
+             &'r rocket::Request<'r>
+             &'r (dyn TypedError<'r> + 'r)
+   = note: required for `rocket::Request<'_>` to implement `FromError<'_>`
+
+warning: unused variable: `foo`
+  --> tests/ui-fail-stable/typed-catchers.rs:20:27
+   |
+20 | fn doesnt_implement_error(foo: &Foo) -> &'static str {
+   |                           ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
+   |
+   = note: `#[warn(unused_variables)]` on by default
+
+warning: unused variable: `foo`
+  --> tests/ui-fail-stable/typed-catchers.rs:25:32
+   |
+25 | fn doesnt_implement_from_error(foo: Foo) -> &'static str {
+   |                                ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
+
+warning: unused variable: `foo`
+  --> tests/ui-fail-stable/typed-catchers.rs:30:21
+   |
+30 | fn request_by_value(foo: Request<'_>) -> &'static str {
+   |                     ^^^ help: if this is intentional, prefix it with an underscore: `_foo`

--- a/core/codegen/tests/ui-fail-stable/typed-uri-bad-type.stderr
+++ b/core/codegen/tests/ui-fail-stable/typed-uri-bad-type.stderr
@@ -2,7 +2,13 @@ error[E0271]: type mismatch resolving `<String as FromParam<'_>>::Error == &str`
   --> tests/ui-fail-stable/typed-uri-bad-type.rs:24:37
    |
 24 | fn optionals(id: Option<i32>, name: Result<String, &str>) {  }
-   |                                     ^^^^^^^^^^^^^^^^^^^^ expected `Empty`, found `&str`
+   |                                     ^^^^^^ expected `Empty`, found `&str`
+
+error[E0271]: type mismatch resolving `<String as FromParam<'_>>::Error == &str`
+  --> tests/ui-fail-stable/typed-uri-bad-type.rs:24:37
+   |
+24 | fn optionals(id: Option<i32>, name: Result<String, &str>) {  }
+   |                                     ^^^^^^^^^^^^^^^^^^^^ expected `&str`, found `Empty`
 
 error[E0277]: the trait bound `usize: FromUriParam<rocket::http::uri::fmt::Path, &str>` is not satisfied
   --> tests/ui-fail-stable/typed-uri-bad-type.rs:15:15
@@ -319,9 +325,8 @@ error[E0277]: the trait bound `rocket::http::uri::Reference<'_>: ValidRoutePrefi
   --> tests/ui-fail-stable/typed-uri-bad-type.rs:79:15
    |
 79 |     uri!(uri!("?foo#bar"), simple(id = "hi"));
-   |          -----^^^^^^^^^^-
-   |          |    |
-   |          |    the trait `ValidRoutePrefix` is not implemented for `rocket::http::uri::Reference<'_>`
+   |          ---  ^^^^^^^^^^ the trait `ValidRoutePrefix` is not implemented for `rocket::http::uri::Reference<'_>`
+   |          |
    |          required by a bound introduced by this call
    |
    = help: the following other types implement trait `ValidRoutePrefix`:
@@ -352,9 +357,8 @@ error[E0277]: the trait bound `rocket::http::uri::Asterisk: ValidRoutePrefix` is
   --> tests/ui-fail-stable/typed-uri-bad-type.rs:80:15
    |
 80 |     uri!(uri!("*"), simple(id = "hi"));
-   |          -----^^^-
-   |          |    |
-   |          |    the trait `ValidRoutePrefix` is not implemented for `rocket::http::uri::Asterisk`
+   |          ---  ^^^ the trait `ValidRoutePrefix` is not implemented for `rocket::http::uri::Asterisk`
+   |          |
    |          required by a bound introduced by this call
    |
    = help: the following other types implement trait `ValidRoutePrefix`:
@@ -385,9 +389,8 @@ error[E0277]: the trait bound `rocket::http::uri::Asterisk: ValidRouteSuffix<roc
   --> tests/ui-fail-stable/typed-uri-bad-type.rs:83:37
    |
 83 |     uri!(_, simple(id = "hi"), uri!("*"));
-   |                                -----^^^-
-   |                                |    |
-   |                                |    the trait `ValidRouteSuffix<rocket::http::uri::Origin<'static>>` is not implemented for `rocket::http::uri::Asterisk`
+   |                                ---  ^^^ the trait `ValidRouteSuffix<rocket::http::uri::Origin<'static>>` is not implemented for `rocket::http::uri::Asterisk`
+   |                                |
    |                                required by a bound introduced by this call
    |
    = help: the following other types implement trait `ValidRouteSuffix<T>`:
@@ -422,9 +425,8 @@ error[E0277]: the trait bound `rocket::http::uri::Origin<'_>: ValidRouteSuffix<r
   --> tests/ui-fail-stable/typed-uri-bad-type.rs:84:37
    |
 84 |     uri!(_, simple(id = "hi"), uri!("/foo/bar"));
-   |                                -----^^^^^^^^^^-
-   |                                |    |
-   |                                |    the trait `ValidRouteSuffix<rocket::http::uri::Origin<'static>>` is not implemented for `rocket::http::uri::Origin<'_>`
+   |                                ---  ^^^^^^^^^^ the trait `ValidRouteSuffix<rocket::http::uri::Origin<'static>>` is not implemented for `rocket::http::uri::Origin<'_>`
+   |                                |
    |                                required by a bound introduced by this call
    |
    = help: the following other types implement trait `ValidRouteSuffix<T>`:
@@ -480,7 +482,7 @@ error[E0277]: the trait bound `i32: FromUriParam<rocket::http::uri::fmt::Path, s
   --> tests/ui-fail-stable/typed-uri-bad-type.rs:58:25
    |
 58 |     uri!(optionals(id = Some(10), name = Ok("bob".into())));
-   |                         ^^^^^^^^ the trait `FromUriParam<rocket::http::uri::fmt::Path, std::option::Option<{integer}>>` is not implemented for `i32`, which is required by `std::option::Option<i32>: FromUriParam<rocket::http::uri::fmt::Path, std::option::Option<{integer}>>`
+   |                         ^^^^ the trait `FromUriParam<rocket::http::uri::fmt::Path, std::option::Option<{integer}>>` is not implemented for `i32`, which is required by `std::option::Option<i32>: FromUriParam<rocket::http::uri::fmt::Path, std::option::Option<{integer}>>`
    |
    = help: the following other types implement trait `FromUriParam<P, T>`:
              <i32 as FromUriParam<P, i32>>

--- a/core/codegen/tests/ui-fail-stable/typed-uris-bad-params.stderr
+++ b/core/codegen/tests/ui-fail-stable/typed-uris-bad-params.stderr
@@ -9,21 +9,21 @@ error: route expects 1 parameter but 2 were supplied
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:71:18
    |
 71 |     uri!(ignored(10, "10"));
-   |                  ^^^^^^^^
+   |                  ^^
 
 error: expected unnamed arguments due to ignored parameters
        = note: uri for route `ignored` ignores 1 path parameters: "/<_>"
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:69:18
    |
 69 |     uri!(ignored(num = 10));
-   |                  ^^^^^^^^
+   |                  ^^^
 
 error: route expects 1 parameter but 2 were supplied
        = note: route `ignored` has uri "/<_>"
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:67:18
    |
 67 |     uri!(ignored(10, 20));
-   |                  ^^^^^^
+   |                  ^^
 
 error: path parameters cannot be ignored
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:63:18
@@ -49,7 +49,7 @@ error: invalid parameters for `has_two` route uri
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:57:18
    |
 57 |     uri!(has_two(id = 100, cookies = "hi"));
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^
 
 error: [help] unknown parameter: `cookies`
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:57:28
@@ -63,7 +63,7 @@ error: invalid parameters for `has_two` route uri
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:55:18
    |
 55 |     uri!(has_two(cookies = "hi", id = 100, id = 10, id = 10));
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^
 
 error: [help] unknown parameter: `cookies`
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:55:18
@@ -83,7 +83,7 @@ error: invalid parameters for `has_two` route uri
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:53:18
    |
 53 |     uri!(has_two(name = "hi"));
-   |                  ^^^^^^^^^^^
+   |                  ^^^^
 
 error: invalid parameters for `has_two` route uri
        = note: uri parameters are: id: i32, name: String
@@ -91,7 +91,7 @@ error: invalid parameters for `has_two` route uri
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:51:18
    |
 51 |     uri!(has_two(id = 100, id = 100, ));
-   |                  ^^^^^^^^^^^^^^^^^^^
+   |                  ^^
 
 error: [help] duplicate parameter: `id`
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:51:28
@@ -104,7 +104,7 @@ error: invalid parameters for `has_one_guarded` route uri
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:49:26
    |
 49 |     uri!(has_one_guarded(id = 100, cookies = "hi"));
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                          ^^
 
 error: [help] unknown parameter: `cookies`
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:49:36
@@ -117,7 +117,7 @@ error: invalid parameters for `has_one_guarded` route uri
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:47:26
    |
 47 |     uri!(has_one_guarded(cookies = "hi", id = 100));
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                          ^^^^^^^
 
 error: [help] unknown parameter: `cookies`
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:47:26
@@ -131,7 +131,7 @@ error: invalid parameters for `has_one` route uri
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:45:18
    |
 45 |     uri!(has_one(name = "hi"));
-   |                  ^^^^^^^^^^^
+   |                  ^^^^
 
 error: [help] unknown parameter: `name`
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:45:18
@@ -144,7 +144,7 @@ error: invalid parameters for `has_one` route uri
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:43:18
    |
 43 |     uri!(has_one(id = 100, id = 100, ));
-   |                  ^^^^^^^^^^^^^^^^^^^
+   |                  ^^
 
 error: [help] duplicate parameter: `id`
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:43:28
@@ -157,7 +157,7 @@ error: invalid parameters for `has_one` route uri
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:41:18
    |
 41 |     uri!(has_one(id = 100, id = 100));
-   |                  ^^^^^^^^^^^^^^^^^^
+   |                  ^^
 
 error: [help] duplicate parameter: `id`
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:41:28
@@ -170,7 +170,7 @@ error: invalid parameters for `has_one` route uri
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:39:18
    |
 39 |     uri!(has_one(name = 100, age = 50, id = 100, id = 50));
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^
 
 error: [help] unknown parameters: `name`, `age`
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:39:18
@@ -189,7 +189,7 @@ error: invalid parameters for `has_one` route uri
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:37:18
    |
 37 |     uri!(has_one(name = 100, age = 50, id = 100));
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^
 
 error: [help] unknown parameters: `name`, `age`
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:37:18
@@ -202,7 +202,7 @@ error: invalid parameters for `has_one` route uri
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:35:18
    |
 35 |     uri!(has_one(name = 100, id = 100));
-   |                  ^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^
 
 error: [help] unknown parameter: `name`
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:35:18
@@ -215,7 +215,7 @@ error: invalid parameters for `has_one` route uri
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:33:18
    |
 33 |     uri!(has_one(id = 100, name = "hi"));
-   |                  ^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^
 
 error: [help] unknown parameter: `name`
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:33:28
@@ -235,28 +235,28 @@ error: route expects 2 parameters but 3 were supplied
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:30:18
    |
 30 |     uri!(has_two(10, "hi", "there"));
-   |                  ^^^^^^^^^^^^^^^^^
+   |                  ^^
 
 error: route expects 1 parameter but 2 were supplied
        = note: route `has_one_guarded` has uri "/<id>"
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:28:26
    |
 28 |     uri!(has_one_guarded("hi", 100));
-   |                          ^^^^^^^^^
+   |                          ^^^^
 
 error: route expects 1 parameter but 2 were supplied
        = note: route `has_one` has uri "/<id>"
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:27:18
    |
 27 |     uri!(has_one("Hello", 23, ));
-   |                  ^^^^^^^^^^^^
+   |                  ^^^^^^^
 
 error: route expects 1 parameter but 2 were supplied
        = note: route `has_one` has uri "/<id>"
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:26:18
    |
 26 |     uri!(has_one(1, 23));
-   |                  ^^^^^
+   |                  ^
 
 error: route expects 1 parameter but 0 were supplied
        = note: route `has_one` has uri "/<id>"
@@ -276,4 +276,10 @@ error[E0271]: type mismatch resolving `<String as FromParam<'_>>::Error == &str`
   --> tests/ui-fail-stable/typed-uris-bad-params.rs:17:37
    |
 17 | fn optionals(id: Option<i32>, name: Result<String, &str>) {  }
-   |                                     ^^^^^^^^^^^^^^^^^^^^ expected `Empty`, found `&str`
+   |                                     ^^^^^^ expected `Empty`, found `&str`
+
+error[E0271]: type mismatch resolving `<String as FromParam<'_>>::Error == &str`
+  --> tests/ui-fail-stable/typed-uris-bad-params.rs:17:37
+   |
+17 | fn optionals(id: Option<i32>, name: Result<String, &str>) {  }
+   |                                     ^^^^^^^^^^^^^^^^^^^^ expected `&str`, found `Empty`

--- a/core/codegen/tests/ui-fail-stable/typed-uris-invalid-syntax.stderr
+++ b/core/codegen/tests/ui-fail-stable/typed-uris-invalid-syntax.stderr
@@ -8,13 +8,13 @@ error: named and unnamed parameters cannot be mixed
   --> tests/ui-fail-stable/typed-uris-invalid-syntax.rs:11:17
    |
 11 |     uri!(simple(id = 100, "Hello"));
-   |                 ^^^^^^^^^^^^^^^^^
+   |                 ^^
 
 error: named and unnamed parameters cannot be mixed
   --> tests/ui-fail-stable/typed-uris-invalid-syntax.rs:12:17
    |
 12 |     uri!(simple("Hello", id = 100));
-   |                 ^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^
 
 error: unexpected token
   --> tests/ui-fail-stable/typed-uris-invalid-syntax.rs:14:16
@@ -23,16 +23,16 @@ error: unexpected token
    |                ^
 
 error: invalid URI: unexpected EOF: expected token ':' at index 5
-  --> tests/ui-fail-stable/typed-uris-invalid-syntax.rs:16:16
+  --> tests/ui-fail-stable/typed-uris-invalid-syntax.rs:16:10
    |
 16 |     uri!("mount", simple);
-   |                ^
+   |          ^^^^^^^
 
 error: invalid URI: unexpected EOF: expected token ':' at index 5
-  --> tests/ui-fail-stable/typed-uris-invalid-syntax.rs:17:16
+  --> tests/ui-fail-stable/typed-uris-invalid-syntax.rs:17:10
    |
 17 |     uri!("mount", simple, "http://");
-   |                ^
+   |          ^^^^^^^
 
 error: URI suffix must contain only query and/or fragment
   --> tests/ui-fail-stable/typed-uris-invalid-syntax.rs:18:28
@@ -47,10 +47,10 @@ error: expected 1, 2, or 3 arguments, found 4
    |                                    ^^^^^^
 
 error: invalid URI: unexpected EOF: expected token ':' at index 5
-  --> tests/ui-fail-stable/typed-uris-invalid-syntax.rs:20:16
+  --> tests/ui-fail-stable/typed-uris-invalid-syntax.rs:20:10
    |
 20 |     uri!("mount", simple(10, "hi"), "http://");
-   |                ^
+   |          ^^^^^^^
 
 error: URI suffix must contain only query and/or fragment
   --> tests/ui-fail-stable/typed-uris-invalid-syntax.rs:21:38
@@ -77,10 +77,10 @@ error: expected 1, 2, or 3 arguments, found 4
    |                                              ^^^^^^
 
 error: invalid URI: unexpected token '<' at index 7
-  --> tests/ui-fail-stable/typed-uris-invalid-syntax.rs:25:18
+  --> tests/ui-fail-stable/typed-uris-invalid-syntax.rs:25:10
    |
 25 |     uri!("/mount/<id>", simple);
-   |                  ^
+   |          ^^^^^^^^^^^^^
 
 error: expected at least 1 argument, found none
   --> tests/ui-fail-stable/typed-uris-invalid-syntax.rs:26:5
@@ -103,10 +103,10 @@ error: unexpected end of input, expected an expression
    |                      ^
 
 error: invalid URI: unexpected EOF: expected some token at index 0
-  --> tests/ui-fail-stable/typed-uris-invalid-syntax.rs:29:11
+  --> tests/ui-fail-stable/typed-uris-invalid-syntax.rs:29:10
    |
 29 |     uri!("*", simple(10), "hi");
-   |           ^
+   |          ^^^
 
 error: URI suffix must contain only query and/or fragment
   --> tests/ui-fail-stable/typed-uris-invalid-syntax.rs:30:40

--- a/core/codegen/tests/ui-fail-stable/typed_error.rs
+++ b/core/codegen/tests/ui-fail-stable/typed_error.rs
@@ -1,0 +1,1 @@
+../ui-fail/typed_error.rs

--- a/core/codegen/tests/ui-fail-stable/typed_error.stderr
+++ b/core/codegen/tests/ui-fail-stable/typed_error.stderr
@@ -1,0 +1,101 @@
+error: only one lifetime is supported
+ --> tests/ui-fail-stable/typed_error.rs:8:14
+  |
+8 | struct Thing1<'a, 'b> {
+  |              ^
+
+error: [note] error occurred while deriving `TypedError`
+ --> tests/ui-fail-stable/typed_error.rs:7:10
+  |
+7 | #[derive(TypedError)]
+  |          ^^^^^^^^^^
+  |
+  = note: this error originates in the derive macro `TypedError` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: [note] error occurred while deriving `Transient`
+ --> tests/ui-fail-stable/typed_error.rs:7:10
+  |
+7 | #[derive(TypedError)]
+  |          ^^^^^^^^^^
+  |
+  = note: this error originates in the derive macro `TypedError` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: only one lifetime is supported
+  --> tests/ui-fail-stable/typed_error.rs:20:12
+   |
+20 | enum Thing3<'a, 'b> {
+   |            ^
+
+error: [note] error occurred while deriving `TypedError`
+  --> tests/ui-fail-stable/typed_error.rs:19:10
+   |
+19 | #[derive(TypedError)]
+   |          ^^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `TypedError` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: [note] error occurred while deriving `Transient`
+  --> tests/ui-fail-stable/typed_error.rs:19:10
+   |
+19 | #[derive(TypedError)]
+   |          ^^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `TypedError` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0601]: `main` function not found in crate `$CRATE`
+  --> tests/ui-fail-stable/typed_error.rs:32:19
+   |
+32 | enum EmptyEnum { }
+   |                   ^ consider adding a `main` function to `$DIR/tests/ui-fail-stable/typed_error.rs`
+
+error[E0277]: the trait bound `InnerNonError: TypedError<'r>` is not satisfied
+  --> tests/ui-fail-stable/typed_error.rs:15:5
+   |
+15 | /     #[error(source)]
+16 | |     inner: InnerNonError,
+   | |_________^ the trait `TypedError<'r>` is not implemented for `InnerNonError`
+   |
+   = help: the following other types implement trait `TypedError<'r>`:
+             <InnerError as TypedError<'r>>
+             <Thing2 as TypedError<'r>>
+             <Thing4 as TypedError<'r>>
+             <EmptyEnum as TypedError<'r>>
+             <rocket::either::Either<L, R> as TypedError<'r>>
+             <rocket::serde::json::serde_json::Error as TypedError<'r>>
+             <rocket::serde::msgpack::Error as TypedError<'r>>
+             <rmp_serde::encode::Error as TypedError<'r>>
+           and $N others
+   = note: required for the cast from `&InnerNonError` to `&(dyn TypedError<'r> + 'r)`
+
+error[E0277]: the trait bound `InnerNonError: TypedError<'r>` is not satisfied
+  --> tests/ui-fail-stable/typed_error.rs:27:7
+   |
+27 |     A(#[error(source)] InnerNonError),
+   |       ^ the trait `TypedError<'r>` is not implemented for `InnerNonError`
+   |
+   = help: the following other types implement trait `TypedError<'r>`:
+             <InnerError as TypedError<'r>>
+             <Thing2 as TypedError<'r>>
+             <Thing4 as TypedError<'r>>
+             <EmptyEnum as TypedError<'r>>
+             <rocket::either::Either<L, R> as TypedError<'r>>
+             <rocket::serde::json::serde_json::Error as TypedError<'r>>
+             <rocket::serde::msgpack::Error as TypedError<'r>>
+             <rmp_serde::encode::Error as TypedError<'r>>
+           and $N others
+   = note: required for the cast from `&InnerNonError` to `&(dyn TypedError<'r> + 'r)`
+
+error[E0004]: non-exhaustive patterns: type `&EmptyEnum` is non-empty
+  --> tests/ui-fail-stable/typed_error.rs:31:10
+   |
+31 | #[derive(TypedError)]
+   |          ^^^^^^^^^^
+   |
+note: `EmptyEnum` defined here
+  --> tests/ui-fail-stable/typed_error.rs:32:6
+   |
+32 | enum EmptyEnum { }
+   |      ^^^^^^^^^
+   = note: the matched value is of type `&EmptyEnum`
+   = note: references are always considered inhabited
+   = note: this error originates in the derive macro `TypedError` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/core/codegen/tests/ui-fail-stable/uri_display.stderr
+++ b/core/codegen/tests/ui-fail-stable/uri_display.stderr
@@ -2,7 +2,7 @@ error: fieldless structs are not supported
  --> tests/ui-fail-stable/uri_display.rs:4:1
   |
 4 | struct Foo1;
-  | ^^^^^^^^^^^^
+  | ^^^^^^
 
 error: [note] error occurred while deriving `UriDisplay`
  --> tests/ui-fail-stable/uri_display.rs:3:10
@@ -16,7 +16,7 @@ error: fieldless structs are not supported
  --> tests/ui-fail-stable/uri_display.rs:7:1
   |
 7 | struct Foo2();
-  | ^^^^^^^^^^^^^^
+  | ^^^^^^
 
 error: [note] error occurred while deriving `UriDisplay`
  --> tests/ui-fail-stable/uri_display.rs:6:10
@@ -86,7 +86,7 @@ error: struct must have exactly one field
   --> tests/ui-fail-stable/uri_display.rs:30:1
    |
 30 | struct Foo8;
-   | ^^^^^^^^^^^^
+   | ^^^^^^
 
 error: [note] error occurred while deriving `UriDisplay`
   --> tests/ui-fail-stable/uri_display.rs:29:10
@@ -100,7 +100,7 @@ error: enums are not supported
   --> tests/ui-fail-stable/uri_display.rs:33:1
    |
 33 | enum Foo9 {  }
-   | ^^^^^^^^^^^^^^
+   | ^^^^
 
 error: [note] error occurred while deriving `UriDisplay`
   --> tests/ui-fail-stable/uri_display.rs:32:10
@@ -113,10 +113,8 @@ error: [note] error occurred while deriving `UriDisplay`
 error: named structs are not supported
   --> tests/ui-fail-stable/uri_display.rs:36:1
    |
-36 | / struct Foo10 {
-37 | |     named: usize
-38 | | }
-   | |_^
+36 | struct Foo10 {
+   | ^^^^^^
 
 error: [note] error occurred while deriving `UriDisplay`
   --> tests/ui-fail-stable/uri_display.rs:35:10

--- a/core/codegen/tests/ui-fail-stable/uri_display_type_errors.stderr
+++ b/core/codegen/tests/ui-fail-stable/uri_display_type_errors.stderr
@@ -25,7 +25,7 @@ error[E0277]: the trait bound `BadType: UriDisplay<rocket::http::uri::fmt::Query
   --> tests/ui-fail-stable/uri_display_type_errors.rs:10:5
    |
 10 |     field: BadType,
-   |     ^^^^^^^^^^^^^^ the trait `UriDisplay<rocket::http::uri::fmt::Query>` is not implemented for `BadType`, which is required by `&BadType: UriDisplay<rocket::http::uri::fmt::Query>`
+   |     ^^^^^ the trait `UriDisplay<rocket::http::uri::fmt::Query>` is not implemented for `BadType`, which is required by `&BadType: UriDisplay<rocket::http::uri::fmt::Query>`
    |
    = help: the following other types implement trait `UriDisplay<P>`:
              <bool as UriDisplay<P>>
@@ -48,7 +48,7 @@ error[E0277]: the trait bound `BadType: UriDisplay<rocket::http::uri::fmt::Query
   --> tests/ui-fail-stable/uri_display_type_errors.rs:16:5
    |
 16 |     bad: BadType,
-   |     ^^^^^^^^^^^^ the trait `UriDisplay<rocket::http::uri::fmt::Query>` is not implemented for `BadType`, which is required by `&BadType: UriDisplay<rocket::http::uri::fmt::Query>`
+   |     ^^^ the trait `UriDisplay<rocket::http::uri::fmt::Query>` is not implemented for `BadType`, which is required by `&BadType: UriDisplay<rocket::http::uri::fmt::Query>`
    |
    = help: the following other types implement trait `UriDisplay<P>`:
              <bool as UriDisplay<P>>
@@ -96,7 +96,7 @@ error[E0277]: the trait bound `BadType: UriDisplay<rocket::http::uri::fmt::Query
   --> tests/ui-fail-stable/uri_display_type_errors.rs:27:9
    |
 27 |         field: BadType,
-   |         ^^^^^^^^^^^^^^ the trait `UriDisplay<rocket::http::uri::fmt::Query>` is not implemented for `BadType`, which is required by `&&BadType: UriDisplay<rocket::http::uri::fmt::Query>`
+   |         ^^^^^ the trait `UriDisplay<rocket::http::uri::fmt::Query>` is not implemented for `BadType`, which is required by `&&BadType: UriDisplay<rocket::http::uri::fmt::Query>`
    |
    = help: the following other types implement trait `UriDisplay<P>`:
              <bool as UriDisplay<P>>
@@ -121,7 +121,7 @@ error[E0277]: the trait bound `BadType: UriDisplay<rocket::http::uri::fmt::Query
   --> tests/ui-fail-stable/uri_display_type_errors.rs:35:9
    |
 35 |         other: BadType,
-   |         ^^^^^^^^^^^^^^ the trait `UriDisplay<rocket::http::uri::fmt::Query>` is not implemented for `BadType`, which is required by `&&BadType: UriDisplay<rocket::http::uri::fmt::Query>`
+   |         ^^^^^ the trait `UriDisplay<rocket::http::uri::fmt::Query>` is not implemented for `BadType`, which is required by `&&BadType: UriDisplay<rocket::http::uri::fmt::Query>`
    |
    = help: the following other types implement trait `UriDisplay<P>`:
              <bool as UriDisplay<P>>

--- a/core/codegen/tests/ui-fail/typed-catchers.rs
+++ b/core/codegen/tests/ui-fail/typed-catchers.rs
@@ -1,0 +1,32 @@
+#[macro_use] extern crate rocket;
+use rocket::request::Request;
+
+fn main() {}
+struct Foo;
+
+#[catch(default, error = "<foo>")]
+fn isnt_ref(foo: std::io::Error) -> &'static str {
+    ""
+}
+
+#[catch(default, error = "<foo>")]
+fn isnt_ref_or_error(foo: Foo) -> &'static str {
+    ""
+}
+
+// TODO: Ideally, this error message shouldn't mention `Transient`, but
+// I don't think it's avoidable. It does mention `TypedError` first.
+#[catch(default, error = "<foo>")]
+fn doesnt_implement_error(foo: &Foo) -> &'static str {
+    ""
+}
+
+#[catch(default)]
+fn doesnt_implement_from_error(foo: Foo) -> &'static str {
+    ""
+}
+
+#[catch(default)]
+fn request_by_value(foo: Request<'_>) -> &'static str {
+    ""
+}

--- a/core/codegen/tests/ui-fail/typed_error.rs
+++ b/core/codegen/tests/ui-fail/typed_error.rs
@@ -1,0 +1,32 @@
+#[macro_use] extern crate rocket;
+
+#[derive(TypedError)]
+struct InnerError;
+struct InnerNonError;
+
+#[derive(TypedError)]
+struct Thing1<'a, 'b> {
+    a: &'a str,
+    b: &'b str,
+}
+
+#[derive(TypedError)]
+struct Thing2 {
+    #[error(source)]
+    inner: InnerNonError,
+}
+
+#[derive(TypedError)]
+enum Thing3<'a, 'b> {
+    A(&'a str),
+    B(&'b str),
+}
+
+#[derive(TypedError)]
+enum Thing4 {
+    A(#[error(source)] InnerNonError),
+    B(#[error(source)] InnerError),
+}
+
+#[derive(TypedError)]
+enum EmptyEnum { }

--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -36,6 +36,7 @@ memchr = "2"
 stable-pattern = "0.1"
 cookie = { version = "0.18", features = ["percent-encode"] }
 state = "0.6"
+transient = { version = "0.2.1" }
 
 [dependencies.serde]
 version = "1.0"

--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -36,7 +36,7 @@ memchr = "2"
 stable-pattern = "0.1"
 cookie = { version = "0.18", features = ["percent-encode"] }
 state = "0.6"
-transient = { version = "0.4" }
+transient = { version = "0.4", path = "/home/matthew/transient" }
 
 [dependencies.serde]
 version = "1.0"

--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -36,7 +36,7 @@ memchr = "2"
 stable-pattern = "0.1"
 cookie = { version = "0.18", features = ["percent-encode"] }
 state = "0.6"
-transient = { version = "0.2.1" }
+transient = { version = "0.3" }
 
 [dependencies.serde]
 version = "1.0"

--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -36,7 +36,7 @@ memchr = "2"
 stable-pattern = "0.1"
 cookie = { version = "0.18", features = ["percent-encode"] }
 state = "0.6"
-transient = { version = "0.3" }
+transient = { version = "0.4" }
 
 [dependencies.serde]
 version = "1.0"

--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -36,7 +36,7 @@ memchr = "2"
 stable-pattern = "0.1"
 cookie = { version = "0.18", features = ["percent-encode"] }
 state = "0.6"
-transient = { version = "0.4", path = "/home/matthew/transient" }
+transient = { version = "0.4", path = "/code/matthew/transient" }
 
 [dependencies.serde]
 version = "1.0"

--- a/core/http/src/status.rs
+++ b/core/http/src/status.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{convert::Infallible, fmt};
 
 use transient::Static;
 
@@ -125,6 +125,12 @@ impl Static for Status {}
 impl Default for Status {
     fn default() -> Self {
         Status::Ok
+    }
+}
+
+impl From<Infallible> for Status {
+    fn from(v: Infallible) -> Self {
+        match v {}
     }
 }
 

--- a/core/http/src/status.rs
+++ b/core/http/src/status.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use transient::Transient;
+use transient::Static;
 
 /// Enumeration of HTTP status classes.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
@@ -114,11 +114,13 @@ impl StatusClass {
 /// }
 /// # }
 /// ```
-#[derive(Debug, Clone, Copy, Transient)]
+#[derive(Debug, Clone, Copy)]
 pub struct Status {
     /// The HTTP status code associated with this status.
     pub code: u16,
 }
+
+impl Static for Status {}
 
 impl Default for Status {
     fn default() -> Self {

--- a/core/http/src/status.rs
+++ b/core/http/src/status.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use transient::Transient;
+
 /// Enumeration of HTTP status classes.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum StatusClass {
@@ -112,7 +114,7 @@ impl StatusClass {
 /// }
 /// # }
 /// ```
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Transient)]
 pub struct Status {
     /// The HTTP status code associated with this status.
     pub code: u16,

--- a/core/http/src/uri/error.rs
+++ b/core/http/src/uri/error.rs
@@ -1,6 +1,7 @@
 //! Errors arising from parsing invalid URIs.
 
 use std::fmt;
+use transient::Static;
 
 pub use crate::parse::uri::Error;
 
@@ -28,6 +29,8 @@ pub enum PathError {
     /// The segment ended with the wrapped invalid character.
     BadEnd(char),
 }
+
+impl Static for PathError {}
 
 impl fmt::Display for PathError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -74,7 +74,7 @@ tokio-stream = { version = "0.1.6", features = ["signal", "time"] }
 cookie = { version = "0.18", features = ["percent-encode"] }
 futures = { version = "0.3.30", default-features = false, features = ["std"] }
 state = "0.6"
-transient = { version = "0.2.0", path = "../../../transient" }
+transient = { version = "0.2.1" }
 
 # tracing
 tracing = { version = "0.1.40", default-features = false, features = ["std", "attributes"] }

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -29,7 +29,7 @@ http3-preview = ["s2n-quic", "s2n-quic-h3", "tls"]
 secrets = ["cookie/private", "cookie/key-expansion"]
 json = ["serde_json"]
 msgpack = ["rmp-serde"]
-uuid = ["uuid_", "rocket_http/uuid"]
+uuid = ["uuid_", "rocket_http/uuid", "transient/uuid"]
 tls = ["rustls", "tokio-rustls", "rustls-pemfile"]
 mtls = ["tls", "x509-parser"]
 tokio-macros = ["tokio/macros"]
@@ -74,7 +74,7 @@ tokio-stream = { version = "0.1.6", features = ["signal", "time"] }
 cookie = { version = "0.18", features = ["percent-encode"] }
 futures = { version = "0.3.30", default-features = false, features = ["std"] }
 state = "0.6"
-transient = { version = "0.3" }
+transient = { version = "0.4" }
 
 # tracing
 tracing = { version = "0.1.40", default-features = false, features = ["std", "attributes"] }

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -27,8 +27,8 @@ default = ["http2", "tokio-macros", "trace"]
 http2 = ["hyper/http2", "hyper-util/http2"]
 http3-preview = ["s2n-quic", "s2n-quic-h3", "tls"]
 secrets = ["cookie/private", "cookie/key-expansion"]
-json = ["serde_json"]
-msgpack = ["rmp-serde"]
+json = ["serde_json", "transient/serde_json"]
+msgpack = ["rmp-serde", "transient/rmp-serde"]
 uuid = ["uuid_", "rocket_http/uuid", "transient/uuid"]
 tls = ["rustls", "tokio-rustls", "rustls-pemfile"]
 mtls = ["tls", "x509-parser"]
@@ -74,7 +74,7 @@ tokio-stream = { version = "0.1.6", features = ["signal", "time"] }
 cookie = { version = "0.18", features = ["percent-encode"] }
 futures = { version = "0.3.30", default-features = false, features = ["std"] }
 state = "0.6"
-transient = { version = "0.4" }
+transient = { version = "0.4", features = ["either"], path = "/home/matthew/transient" }
 
 # tracing
 tracing = { version = "0.1.40", default-features = false, features = ["std", "attributes"] }

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -129,6 +129,7 @@ optional = true
 
 [dependencies.s2n-quic-h3]
 git = "https://github.com/SergioBenitez/s2n-quic-h3.git"
+rev = "865fd25"
 optional = true
 
 [target.'cfg(unix)'.dependencies]

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -74,7 +74,7 @@ tokio-stream = { version = "0.1.6", features = ["signal", "time"] }
 cookie = { version = "0.18", features = ["percent-encode"] }
 futures = { version = "0.3.30", default-features = false, features = ["std"] }
 state = "0.6"
-transient = { version = "0.2.1" }
+transient = { version = "0.3" }
 
 # tracing
 tracing = { version = "0.1.40", default-features = false, features = ["std", "attributes"] }

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -74,7 +74,7 @@ tokio-stream = { version = "0.1.6", features = ["signal", "time"] }
 cookie = { version = "0.18", features = ["percent-encode"] }
 futures = { version = "0.3.30", default-features = false, features = ["std"] }
 state = "0.6"
-transient = { version = "0.4", features = ["either"], path = "/home/matthew/transient" }
+transient = { version = "0.4", features = ["either"], path = "/code/matthew/transient" }
 
 # tracing
 tracing = { version = "0.1.40", default-features = false, features = ["std", "attributes"] }

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -74,6 +74,7 @@ tokio-stream = { version = "0.1.6", features = ["signal", "time"] }
 cookie = { version = "0.18", features = ["percent-encode"] }
 futures = { version = "0.3.30", default-features = false, features = ["std"] }
 state = "0.6"
+transient = { version = "0.2.0", path = "../../../transient" }
 
 # tracing
 tracing = { version = "0.1.40", default-features = false, features = ["std", "attributes"] }

--- a/core/lib/src/catcher/catcher.rs
+++ b/core/lib/src/catcher/catcher.rs
@@ -8,9 +8,7 @@ use crate::http::ext::IntoOwned;
 use crate::response::Response;
 use crate::request::Request;
 use crate::http::{Status, ContentType, uri};
-use crate::catcher::{Handler, BoxFuture};
-
-use super::ErasedError;
+use crate::catcher::{BoxFuture, TypedError, Handler};
 
 /// An error catching route.
 ///
@@ -324,7 +322,7 @@ impl Catcher {
 
 impl Default for Catcher {
     fn default() -> Self {
-        fn handler<'r>(s: Status, req: &'r Request<'_>, _e: ErasedError<'r>) -> BoxFuture<'r> {
+        fn handler<'r>(s: Status, req: &'r Request<'_>, _e: Option<&(dyn TypedError<'r> + 'r)>) -> BoxFuture<'r> {
             Box::pin(async move { Ok(default_handler(s, req)) })
         }
 
@@ -344,7 +342,7 @@ pub struct StaticInfo {
     /// The catcher's error type.
     pub error_type: Option<(TypeId, &'static str)>,
     /// The catcher's handler, i.e, the annotated function.
-    pub handler: for<'r> fn(Status, &'r Request<'_>, ErasedError<'r>) -> BoxFuture<'r>,
+    pub handler: for<'r> fn(Status, &'r Request<'_>, Option<&'r (dyn TypedError<'r> + 'r)>) -> BoxFuture<'r>,
     /// The file, line, and column where the catcher was defined.
     pub location: (&'static str, u32, u32),
 }

--- a/core/lib/src/catcher/catcher.rs
+++ b/core/lib/src/catcher/catcher.rs
@@ -145,26 +145,26 @@ impl Catcher {
     ///
     /// ```rust
     /// use rocket::request::Request;
-    /// use rocket::catcher::{Catcher, BoxFuture, ErasedError};
+    /// use rocket::catcher::{Catcher, BoxFuture, TypedError};
     /// use rocket::response::Responder;
     /// use rocket::http::Status;
     ///
-    /// fn handle_404<'r>(status: Status, req: &'r Request<'_>, _e: ErasedError<'r>)
+    /// fn handle_404<'r>(status: Status, req: &'r Request<'_>, _e: Option<&'r dyn TypedError<'r>>)
     ///    -> BoxFuture<'r>
     /// {
     ///    let res = (status, format!("404: {}", req.uri()));
-    ///    Box::pin(async move { res.respond_to(req).map_err(|s| (s, _e)) })
+    ///    Box::pin(async move { res.respond_to(req).responder_error() })
     /// }
     ///
-    /// fn handle_500<'r>(_: Status, req: &'r Request<'_>, _e: ErasedError<'r>) -> BoxFuture<'r> {
-    ///     Box::pin(async move{ "Whoops, we messed up!".respond_to(req).map_err(|s| (s, _e)) })
+    /// fn handle_500<'r>(_: Status, req: &'r Request<'_>, _e: Option<&'r dyn TypedError<'r>>) -> BoxFuture<'r> {
+    ///     Box::pin(async move{ "Whoops, we messed up!".respond_to(req).responder_error() })
     /// }
     ///
-    /// fn handle_default<'r>(status: Status, req: &'r Request<'_>, _e: ErasedError<'r>)
+    /// fn handle_default<'r>(status: Status, req: &'r Request<'_>, _e: Option<&'r dyn TypedError<'r>>)
     ///    -> BoxFuture<'r>
     /// {
     ///    let res = (status, format!("{}: {}", status, req.uri()));
-    ///    Box::pin(async move { res.respond_to(req).map_err(|s| (s, _e)) })
+    ///    Box::pin(async move { res.respond_to(req).responder_error() })
     /// }
     ///
     /// let not_found_catcher = Catcher::new(404, handle_404);
@@ -202,15 +202,15 @@ impl Catcher {
     ///
     /// ```rust
     /// use rocket::request::Request;
-    /// use rocket::catcher::{Catcher, BoxFuture, ErasedError};
+    /// use rocket::catcher::{Catcher, BoxFuture, TypedError};
     /// use rocket::response::Responder;
     /// use rocket::http::Status;
     ///
-    /// fn handle_404<'r>(status: Status, req: &'r Request<'_>, _e: ErasedError<'r>)
+    /// fn handle_404<'r>(status: Status, req: &'r Request<'_>, _e: Option<&'r dyn TypedError<'r>>)
     ///    -> BoxFuture<'r>
     /// {
     ///    let res = (status, format!("404: {}", req.uri()));
-    ///    Box::pin(async move { res.respond_to(req).map_err(|s| (s, _e)) })
+    ///    Box::pin(async move { res.respond_to(req).responder_error() })
     /// }
     ///
     /// let catcher = Catcher::new(404, handle_404);
@@ -230,16 +230,16 @@ impl Catcher {
     ///
     /// ```rust
     /// use rocket::request::Request;
-    /// use rocket::catcher::{Catcher, BoxFuture, ErasedError};
+    /// use rocket::catcher::{Catcher, BoxFuture, TypedError};
     /// use rocket::response::Responder;
     /// use rocket::http::Status;
     /// # use rocket::uri;
     ///
-    /// fn handle_404<'r>(status: Status, req: &'r Request<'_>, _e: ErasedError<'r>)
+    /// fn handle_404<'r>(status: Status, req: &'r Request<'_>, _e: Option<&'r dyn TypedError<'r>>)
     ///    -> BoxFuture<'r>
     /// {
     ///    let res = (status, format!("404: {}", req.uri()));
-    ///    Box::pin(async move { res.respond_to(req).map_err(|s| (s, _e)) })
+    ///    Box::pin(async move { res.respond_to(req).responder_error() })
     /// }
     ///
     /// let catcher = Catcher::new(404, handle_404);
@@ -286,15 +286,15 @@ impl Catcher {
     ///
     /// ```rust
     /// use rocket::request::Request;
-    /// use rocket::catcher::{Catcher, BoxFuture, ErasedError};
+    /// use rocket::catcher::{Catcher, BoxFuture, TypedError};
     /// use rocket::response::Responder;
     /// use rocket::http::Status;
     ///
-    /// fn handle_404<'r>(status: Status, req: &'r Request<'_>, _e: ErasedError<'r>)
+    /// fn handle_404<'r>(status: Status, req: &'r Request<'_>, _e: Option<&'r dyn TypedError<'r>>)
     ///    -> BoxFuture<'r>
     /// {
     ///    let res = (status, format!("404: {}", req.uri()));
-    ///    Box::pin(async move { res.respond_to(req).map_err(|s| (s, _e)) })
+    ///    Box::pin(async move { res.respond_to(req).responder_error() })
     /// }
     ///
     /// let catcher = Catcher::new(404, handle_404);

--- a/core/lib/src/catcher/catcher.rs
+++ b/core/lib/src/catcher/catcher.rs
@@ -133,7 +133,7 @@ pub struct Catcher {
 // with more nonempty segments have lower ranks => higher precedence.
 // Doubled to provide space between for typed catchers.
 fn rank(base: Path<'_>) -> isize {
-    -(base.segments().filter(|s| !s.is_empty()).count() as isize) * 2
+    -(base.segments().filter(|s| !s.is_empty()).count() as isize)
 }
 
 impl Catcher {
@@ -355,11 +355,6 @@ impl From<StaticInfo> for Catcher {
     #[inline]
     fn from(info: StaticInfo) -> Catcher {
         let mut catcher = Catcher::new(info.code, info.handler);
-        if info.error_type.is_some() {
-            // Lower rank if the error_type is defined, to ensure typed catchers
-            // are always tried first
-            catcher.rank -= 1;
-        }
         catcher.name = Some(info.name.into());
         catcher.error_type = info.error_type;
         catcher.location = Some(info.location);

--- a/core/lib/src/catcher/catcher.rs
+++ b/core/lib/src/catcher/catcher.rs
@@ -86,7 +86,7 @@ use crate::catcher::{BoxFuture, TypedError, Handler};
 ///     format!("I couldn't find '{}'. Try something else?", uri)
 /// }
 ///
-/// #[catch(default, status = "<status>")]
+/// #[catch(default)]
 /// fn default(status: Status, uri: &Origin) -> String {
 ///     format!("{} ({})", status, uri)
 /// }

--- a/core/lib/src/catcher/catcher.rs
+++ b/core/lib/src/catcher/catcher.rs
@@ -8,7 +8,7 @@ use crate::request::Request;
 use crate::http::{Status, ContentType, uri};
 use crate::catcher::{Handler, BoxFuture};
 
-use super::ErasedErrorRef;
+use super::ErasedError;
 
 /// An error catching route.
 ///
@@ -315,7 +315,7 @@ impl Catcher {
 
 impl Default for Catcher {
     fn default() -> Self {
-        fn handler<'r>(s: Status, req: &'r Request<'_>, _e: &ErasedErrorRef<'r>) -> BoxFuture<'r> {
+        fn handler<'r>(s: Status, req: &'r Request<'_>, _e: ErasedError<'r>) -> BoxFuture<'r> {
             Box::pin(async move { Ok(default_handler(s, req)) })
         }
 
@@ -333,7 +333,7 @@ pub struct StaticInfo {
     /// The catcher's status code.
     pub code: Option<u16>,
     /// The catcher's handler, i.e, the annotated function.
-    pub handler: for<'r> fn(Status, &'r Request<'_>, &ErasedErrorRef<'r>) -> BoxFuture<'r>,
+    pub handler: for<'r> fn(Status, &'r Request<'_>, ErasedError<'r>) -> BoxFuture<'r>,
     /// The file, line, and column where the catcher was defined.
     pub location: (&'static str, u32, u32),
 }

--- a/core/lib/src/catcher/catcher.rs
+++ b/core/lib/src/catcher/catcher.rs
@@ -322,7 +322,9 @@ impl Catcher {
 
 impl Default for Catcher {
     fn default() -> Self {
-        fn handler<'r>(s: Status, req: &'r Request<'_>, _e: Option<&(dyn TypedError<'r> + 'r)>) -> BoxFuture<'r> {
+        fn handler<'r>(s: Status, req: &'r Request<'_>, _e: Option<&'r dyn TypedError<'r>>)
+            -> BoxFuture<'r>
+        {
             Box::pin(async move { Ok(default_handler(s, req)) })
         }
 
@@ -342,7 +344,8 @@ pub struct StaticInfo {
     /// The catcher's error type.
     pub error_type: Option<(TypeId, &'static str)>,
     /// The catcher's handler, i.e, the annotated function.
-    pub handler: for<'r> fn(Status, &'r Request<'_>, Option<&'r (dyn TypedError<'r> + 'r)>) -> BoxFuture<'r>,
+    pub handler: for<'r> fn(Status, &'r Request<'_>, Option<&'r dyn TypedError<'r>>)
+            -> BoxFuture<'r>,
     /// The file, line, and column where the catcher was defined.
     pub location: (&'static str, u32, u32),
 }

--- a/core/lib/src/catcher/catcher.rs
+++ b/core/lib/src/catcher/catcher.rs
@@ -153,18 +153,18 @@ impl Catcher {
     ///    -> BoxFuture<'r>
     /// {
     ///    let res = (status, format!("404: {}", req.uri()));
-    ///    Box::pin(async move { res.respond_to(req).responder_error() })
+    ///    Box::pin(async move { res.respond_to(req).map_err(|e| e.into()) })
     /// }
     ///
     /// fn handle_500<'r>(_: Status, req: &'r Request<'_>, _e: Option<&'r dyn TypedError<'r>>) -> BoxFuture<'r> {
-    ///     Box::pin(async move{ "Whoops, we messed up!".respond_to(req).responder_error() })
+    ///     Box::pin(async move{ "Whoops, we messed up!".respond_to(req).map_err(|e| e.into()) })
     /// }
     ///
     /// fn handle_default<'r>(status: Status, req: &'r Request<'_>, _e: Option<&'r dyn TypedError<'r>>)
     ///    -> BoxFuture<'r>
     /// {
     ///    let res = (status, format!("{}: {}", status, req.uri()));
-    ///    Box::pin(async move { res.respond_to(req).responder_error() })
+    ///    Box::pin(async move { res.respond_to(req).map_err(|e| e.into()) })
     /// }
     ///
     /// let not_found_catcher = Catcher::new(404, handle_404);
@@ -210,7 +210,7 @@ impl Catcher {
     ///    -> BoxFuture<'r>
     /// {
     ///    let res = (status, format!("404: {}", req.uri()));
-    ///    Box::pin(async move { res.respond_to(req).responder_error() })
+    ///    Box::pin(async move { res.respond_to(req).map_err(|e| e.into()) })
     /// }
     ///
     /// let catcher = Catcher::new(404, handle_404);
@@ -239,7 +239,7 @@ impl Catcher {
     ///    -> BoxFuture<'r>
     /// {
     ///    let res = (status, format!("404: {}", req.uri()));
-    ///    Box::pin(async move { res.respond_to(req).responder_error() })
+    ///    Box::pin(async move { res.respond_to(req).map_err(|e| e.into()) })
     /// }
     ///
     /// let catcher = Catcher::new(404, handle_404);
@@ -294,7 +294,7 @@ impl Catcher {
     ///    -> BoxFuture<'r>
     /// {
     ///    let res = (status, format!("404: {}", req.uri()));
-    ///    Box::pin(async move { res.respond_to(req).responder_error() })
+    ///    Box::pin(async move { res.respond_to(req).map_err(|e| e.into()) })
     /// }
     ///
     /// let catcher = Catcher::new(404, handle_404);

--- a/core/lib/src/catcher/catcher.rs
+++ b/core/lib/src/catcher/catcher.rs
@@ -76,8 +76,7 @@ use super::ErasedError;
 /// ```rust,no_run
 /// #[macro_use] extern crate rocket;
 ///
-/// use rocket::Request;
-/// use rocket::http::Status;
+/// use rocket::http::{Status, uri::Origin};
 ///
 /// #[catch(500)]
 /// fn internal_error() -> &'static str {
@@ -85,13 +84,13 @@ use super::ErasedError;
 /// }
 ///
 /// #[catch(404)]
-/// fn not_found(req: &Request) -> String {
-///     format!("I couldn't find '{}'. Try something else?", req.uri())
+/// fn not_found(uri: &Origin) -> String {
+///     format!("I couldn't find '{}'. Try something else?", uri)
 /// }
 ///
-/// #[catch(default)]
-/// fn default(status: Status, req: &Request) -> String {
-///     format!("{} ({})", status, req.uri())
+/// #[catch(default, status = "<status>")]
+/// fn default(status: Status, uri: &Origin) -> String {
+///     format!("{} ({})", status, uri)
 /// }
 ///
 /// #[launch]
@@ -99,13 +98,6 @@ use super::ErasedError;
 ///     rocket::build().register("/", catchers![internal_error, not_found, default])
 /// }
 /// ```
-///
-/// A function decorated with `#[catch]` may take zero, one, or two arguments.
-/// It's type signature must be one of the following, where `R:`[`Responder`]:
-///
-///   * `fn() -> R`
-///   * `fn(`[`&Request`]`) -> R`
-///   * `fn(`[`Status`]`, `[`&Request`]`) -> R`
 ///
 /// See the [`catch`] documentation for full details.
 ///

--- a/core/lib/src/catcher/from_error.rs
+++ b/core/lib/src/catcher/from_error.rs
@@ -1,0 +1,96 @@
+use async_trait::async_trait;
+
+use crate::http::Status;
+use crate::outcome::Outcome;
+use crate::request::FromRequest;
+use crate::Request;
+
+use crate::catcher::TypedError;
+
+// TODO: update docs and do links
+/// Trait used to extract types for an error catcher. You should
+/// pretty much never implement this yourself. There are several
+/// existing implementations, that should cover every need.
+///
+/// - `Status`: Extracts the HTTP status that this error is catching.
+/// - `&Request<'_>`: Extracts a reference to the entire request that
+///     triggered this error to begin with.
+/// - `T: FromRequest<'_>`: Extracts type that implements `FromRequest`
+/// - `&dyn TypedError<'_>`: Extracts the typed error, as a dynamic
+///     trait object.
+/// - `Option<&dyn TypedError<'_>>`: Same as previous, but succeeds even
+///     if there is no typed error to extract.
+#[async_trait]
+pub trait FromError<'r>: Sized {
+    async fn from_error(
+        status: Status,
+        request: &'r Request<'r>,
+        error: Option<&'r dyn TypedError<'r>>
+    ) -> Result<Self, Status>;
+}
+
+#[async_trait]
+impl<'r> FromError<'r> for Status {
+    async fn from_error(
+        status: Status,
+        _r: &'r Request<'r>,
+        _e: Option<&'r dyn TypedError<'r>>
+    ) -> Result<Self, Status> {
+        Ok(status)
+    }
+}
+
+#[async_trait]
+impl<'r> FromError<'r> for &'r Request<'r> {
+    async fn from_error(
+        _s: Status,
+        req: &'r Request<'r>,
+        _e: Option<&'r dyn TypedError<'r>>
+    ) -> Result<Self, Status> {
+        Ok(req)
+    }
+}
+
+#[async_trait]
+impl<'r, T: FromRequest<'r>> FromError<'r> for T {
+    async fn from_error(
+        _s: Status,
+        req: &'r Request<'r>,
+        _e: Option<&'r dyn TypedError<'r>>
+    ) -> Result<Self, Status> {
+        match T::from_request(req).await {
+            Outcome::Success(val) => Ok(val),
+            Outcome::Error((s, e)) => {
+                info!(status = %s, "Catcher guard error: {:?}", e);
+                Err(s)
+            },
+            Outcome::Forward(s) => {
+                info!(status = %s, "Catcher guard forwarding");
+                Err(s)
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl<'r> FromError<'r> for &'r dyn TypedError<'r> {
+    async fn from_error(
+        _s: Status,
+        _r: &'r Request<'r>,
+        error: Option<&'r dyn TypedError<'r>>
+    ) -> Result<Self, Status> {
+        // TODO: what's the correct status here? Not Found?
+        error.ok_or(Status::InternalServerError)
+    }
+}
+
+#[async_trait]
+impl<'r> FromError<'r> for Option<&'r dyn TypedError<'r>> {
+    async fn from_error(
+        _s: Status,
+        _r: &'r Request<'r>,
+        error: Option<&'r dyn TypedError<'r>>
+    ) -> Result<Self, Status> {
+        Ok(error)
+    }
+}

--- a/core/lib/src/catcher/from_error.rs
+++ b/core/lib/src/catcher/from_error.rs
@@ -60,9 +60,10 @@ impl<'r, T: FromRequest<'r>> FromError<'r> for T {
     ) -> Result<Self, Status> {
         match T::from_request(req).await {
             Outcome::Success(val) => Ok(val),
-            Outcome::Error((s, e)) => {
-                info!(status = %s, "Catcher guard error: {:?}", e);
-                Err(s)
+            Outcome::Error(e) => {
+                // TODO: This should be an actual status
+                info!("Catcher guard error: {:?}", e);
+                Err(Status::InternalServerError)
             },
             Outcome::Forward(s) => {
                 info!(status = %s, "Catcher guard forwarding");

--- a/core/lib/src/catcher/from_error.rs
+++ b/core/lib/src/catcher/from_error.rs
@@ -7,19 +7,23 @@ use crate::Request;
 
 use crate::catcher::TypedError;
 
-// TODO: update docs and do links
 /// Trait used to extract types for an error catcher. You should
 /// pretty much never implement this yourself. There are several
 /// existing implementations, that should cover every need.
 ///
-/// - `Status`: Extracts the HTTP status that this error is catching.
-/// - `&Request<'_>`: Extracts a reference to the entire request that
+/// - [`Status`]: Extracts the HTTP status that this error is catching.
+/// - [`&Request<'_>`]: Extracts a reference to the entire request that
 ///     triggered this error to begin with.
-/// - `T: FromRequest<'_>`: Extracts type that implements `FromRequest`
-/// - `&dyn TypedError<'_>`: Extracts the typed error, as a dynamic
+/// - [`T: FromRequest<'_>`]: Extracts type that implements `FromRequest`
+/// - [`&dyn TypedError<'_>`]: Extracts the typed error, as a dynamic
 ///     trait object.
-/// - `Option<&dyn TypedError<'_>>`: Same as previous, but succeeds even
+/// - [`Option<&dyn TypedError<'_>>`]: Same as previous, but succeeds even
 ///     if there is no typed error to extract.
+///
+/// [`Status`]: crate::http::Status
+/// [`&Request<'_>`]: crate::request::Request
+/// [`&dyn TypedError<'_>`]: crate::catcher::TypedError
+/// [`Option<&dyn TypedError<'_>>`]: crate::catcher::TypedError
 #[async_trait]
 pub trait FromError<'r>: Sized {
     async fn from_error(
@@ -61,9 +65,8 @@ impl<'r, T: FromRequest<'r>> FromError<'r> for T {
         match T::from_request(req).await {
             Outcome::Success(val) => Ok(val),
             Outcome::Error(e) => {
-                // TODO: This should be an actual status
-                info!("Catcher guard error: {:?}", e);
-                Err(Status::InternalServerError)
+                info!("Catcher guard error type: `{:?}`", e.name());
+                Err(e.status())
             },
             Outcome::Forward(s) => {
                 info!(status = %s, "Catcher guard forwarding");
@@ -80,7 +83,6 @@ impl<'r> FromError<'r> for &'r dyn TypedError<'r> {
         _r: &'r Request<'r>,
         error: Option<&'r dyn TypedError<'r>>
     ) -> Result<Self, Status> {
-        // TODO: what's the correct status here? Not Found?
         error.ok_or(Status::InternalServerError)
     }
 }

--- a/core/lib/src/catcher/handler.rs
+++ b/core/lib/src/catcher/handler.rs
@@ -30,7 +30,7 @@ pub type BoxFuture<'r, T = Result<'r>> = futures::future::BoxFuture<'r, T>;
 /// and used as follows:
 ///
 /// ```rust,no_run
-/// use rocket::{Request, Catcher, catcher::{self, ErasedError}};
+/// use rocket::{Request, Catcher, catcher::{self, TypedError}};
 /// use rocket::response::{Response, Responder};
 /// use rocket::http::Status;
 ///
@@ -46,16 +46,16 @@ pub type BoxFuture<'r, T = Result<'r>> = futures::future::BoxFuture<'r, T>;
 ///
 /// #[rocket::async_trait]
 /// impl catcher::Handler for CustomHandler {
-///     async fn handle<'r>(&self, status: Status, req: &'r Request<'_>, _e: ErasedError<'r>)
+///     async fn handle<'r>(&self, status: Status, req: &'r Request<'_>, _e: Option<&'r dyn TypedError<'r>>)
 ///         -> catcher::Result<'r>
 ///     {
 ///         let inner = match self.0 {
-///             Kind::Simple => "simple".respond_to(req).map_err(|e| (e, _e))?,
-///             Kind::Intermediate => "intermediate".respond_to(req).map_err(|e| (e, _e))?,
-///             Kind::Complex => "complex".respond_to(req).map_err(|e| (e, _e))?,
+///             Kind::Simple => "simple".respond_to(req).responder_error()?,
+///             Kind::Intermediate => "intermediate".respond_to(req).responder_error()?,
+///             Kind::Complex => "complex".respond_to(req).responder_error()?,
 ///         };
 ///
-///         Response::build_from(inner).status(status).ok()
+///         Response::build_from(inner).status(status).ok::<()>().responder_error()
 ///     }
 /// }
 ///

--- a/core/lib/src/catcher/handler.rs
+++ b/core/lib/src/catcher/handler.rs
@@ -1,11 +1,10 @@
 use crate::{Request, Response};
+use crate::catcher::TypedError;
 use crate::http::Status;
-
-use super::ErasedError;
 
 /// Type alias for the return type of a [`Catcher`](crate::Catcher)'s
 /// [`Handler::handle()`].
-pub type Result<'r> = std::result::Result<Response<'r>, (crate::http::Status, ErasedError<'r>)>;
+pub type Result<'r> = std::result::Result<Response<'r>, crate::http::Status>;
 
 /// Type alias for the return type of a _raw_ [`Catcher`](crate::Catcher)'s
 /// [`Handler`].
@@ -101,19 +100,19 @@ pub trait Handler: Cloneable + Send + Sync + 'static {
     /// Nevertheless, failure is allowed, both for convenience and necessity. If
     /// an error handler fails, Rocket's default `500` catcher is invoked. If it
     /// succeeds, the returned `Response` is used to respond to the client.
-    async fn handle<'r>(&self, status: Status, req: &'r Request<'_>, error: ErasedError<'r>)
+    async fn handle<'r>(&self, status: Status, req: &'r Request<'_>, error: Option<&'r (dyn TypedError<'r> + 'r)>)
         -> Result<'r>;
 }
 
 // We write this manually to avoid double-boxing.
 impl<F: Clone + Sync + Send + 'static> Handler for F
-    where for<'x> F: Fn(Status, &'x Request<'_>, ErasedError<'x>) -> BoxFuture<'x>,
+    where for<'x> F: Fn(Status, &'x Request<'_>, Option<&'x (dyn TypedError<'x> + 'x)>) -> BoxFuture<'x>,
 {
-    fn handle<'r, 'life0, 'life1, 'async_trait>(
+    fn handle<'r, 'life0, 'life1, 'life2, 'async_trait>(
         &'life0 self,
         status: Status,
         req: &'r Request<'life1>,
-        error: ErasedError<'r>,
+        error: Option<&'r (dyn TypedError<'r> + 'r)>,
     ) -> BoxFuture<'r>
         where 'r: 'async_trait,
               'life0: 'async_trait,
@@ -126,7 +125,7 @@ impl<F: Clone + Sync + Send + 'static> Handler for F
 
 // Used in tests! Do not use, please.
 #[doc(hidden)]
-pub fn dummy_handler<'r>(_: Status, _: &'r Request<'_>, _: ErasedError<'r>) -> BoxFuture<'r> {
+pub fn dummy_handler<'r>(_: Status, _: &'r Request<'_>, _: Option<&(dyn TypedError<'r> + 'r)>) -> BoxFuture<'r> {
    Box::pin(async move { Ok(Response::new()) })
 }
 

--- a/core/lib/src/catcher/handler.rs
+++ b/core/lib/src/catcher/handler.rs
@@ -50,12 +50,12 @@ pub type BoxFuture<'r, T = Result<'r>> = futures::future::BoxFuture<'r, T>;
 ///         -> catcher::Result<'r>
 ///     {
 ///         let inner = match self.0 {
-///             Kind::Simple => "simple".respond_to(req).responder_error()?,
-///             Kind::Intermediate => "intermediate".respond_to(req).responder_error()?,
-///             Kind::Complex => "complex".respond_to(req).responder_error()?,
+///             Kind::Simple => "simple".respond_to(req)?,
+///             Kind::Intermediate => "intermediate".respond_to(req)?,
+///             Kind::Complex => "complex".respond_to(req)?,
 ///         };
 ///
-///         Response::build_from(inner).status(status).ok::<()>().responder_error()
+///         Response::build_from(inner).status(status).ok()
 ///     }
 /// }
 ///

--- a/core/lib/src/catcher/mod.rs
+++ b/core/lib/src/catcher/mod.rs
@@ -3,7 +3,9 @@
 mod catcher;
 mod handler;
 mod types;
+mod from_error;
 
 pub use catcher::*;
 pub use handler::*;
 pub use types::*;
+pub use from_error::*;

--- a/core/lib/src/catcher/mod.rs
+++ b/core/lib/src/catcher/mod.rs
@@ -2,6 +2,8 @@
 
 mod catcher;
 mod handler;
+mod types;
 
 pub use catcher::*;
 pub use handler::*;
+pub use types::*;

--- a/core/lib/src/catcher/types.rs
+++ b/core/lib/src/catcher/types.rs
@@ -143,8 +143,9 @@ pub fn type_id_of<'r, T: TypedError<'r> + Transient + 'r>() -> (TypeId, &'static
 
 /// Downcast an error type to the underlying concrete type. Used by the `#[catch]` attribute.
 #[doc(hidden)]
-pub fn downcast<'r, T: TypedError<'r> + Transient + 'r>(v: Option<&'r dyn TypedError<'r>>) -> Option<&'r T>
-    where T::Transience: CanRecoverFrom<Inv<'r>>
+pub fn downcast<'r, T>(v: Option<&'r dyn TypedError<'r>>) -> Option<&'r T>
+    where T: TypedError<'r> + Transient + 'r,
+          T::Transience: CanRecoverFrom<Inv<'r>>,
 {
     // if v.is_none() {
     //     crate::trace::error!("No value to downcast from");

--- a/core/lib/src/catcher/types.rs
+++ b/core/lib/src/catcher/types.rs
@@ -52,6 +52,7 @@ pub trait TypedError<'r>: AsAny<Inv<'r>> + Send + Sync + 'r {
     fn source(&'r self) -> Option<&'r (dyn TypedError<'r> + 'r)> { None }
 
     /// Status code
+    // TODO: This is currently only used for errors produced by Fairings
     fn status(&self) -> Status { Status::InternalServerError }
 }
 
@@ -71,6 +72,10 @@ impl<'r> TypedError<'r> for std::io::Error {
 impl<'r> TypedError<'r> for std::num::ParseIntError {}
 impl<'r> TypedError<'r> for std::num::ParseFloatError {}
 impl<'r> TypedError<'r> for std::string::FromUtf8Error {}
+
+impl TypedError<'_> for Status {
+    fn status(&self) -> Status { *self }
+}
 
 #[cfg(feature = "json")]
 impl<'r> TypedError<'r> for serde_json::Error {}

--- a/core/lib/src/catcher/types.rs
+++ b/core/lib/src/catcher/types.rs
@@ -134,7 +134,16 @@ impl<'r> TypedError<'r> for AnyError<'r> {
     }
 }
 
-pub fn downcast<'r, T: Transient + 'r>(v: Option<&'r dyn TypedError<'r>>) -> Option<&'r T>
+/// Validates that a type implements `TypedError`. Used by the `#[catch]` attribute to ensure
+/// the `TypeError` is first in the diagnostics.
+#[doc(hidden)]
+pub fn type_id_of<'r, T: TypedError<'r> + Transient + 'r>() -> (TypeId, &'static str) {
+    (TypeId::of::<T>(), std::any::type_name::<T>())
+}
+
+/// Downcast an error type to the underlying concrete type. Used by the `#[catch]` attribute.
+#[doc(hidden)]
+pub fn downcast<'r, T: TypedError<'r> + Transient + 'r>(v: Option<&'r dyn TypedError<'r>>) -> Option<&'r T>
     where T::Transience: CanRecoverFrom<Inv<'r>>
 {
     // if v.is_none() {

--- a/core/lib/src/catcher/types.rs
+++ b/core/lib/src/catcher/types.rs
@@ -1,6 +1,6 @@
 use transient::{Any, CanRecoverFrom, Co, Downcast};
 #[doc(inline)]
-pub use transient::{Static, Transient};
+pub use transient::{Static, Transient, TypeId};
 
 pub type ErasedError<'r> = Box<dyn Any<Co<'r>> + Send + Sync + 'r>;
 pub type ErasedErrorRef<'r> = dyn Any<Co<'r>> + Send + Sync + 'r;

--- a/core/lib/src/catcher/types.rs
+++ b/core/lib/src/catcher/types.rs
@@ -1,22 +1,94 @@
-use transient::{Any, CanRecoverFrom, Co, Downcast};
+use either::Either;
+use transient::{Any, CanRecoverFrom, Inv, Downcast, Transience};
+use crate::{http::Status, Request, Response};
 #[doc(inline)]
 pub use transient::{Static, Transient, TypeId};
 
-pub type ErasedError<'r> = Box<dyn Any<Co<'r>> + Send + Sync + 'r>;
-pub type ErasedErrorRef<'r> = dyn Any<Co<'r>> + Send + Sync + 'r;
-
-pub fn default_error_type<'r>() -> ErasedError<'r> {
-    Box::new(())
+/// Polyfill for trait upcasting to [`Any`]
+pub trait AsAny<Tr: Transience>: Any<Tr> + Sealed {
+    /// The actual upcast
+    fn as_any(&self) -> &dyn Any<Tr>;
+    /// convience typeid of the inner typeid
+    fn trait_obj_typeid(&self) -> TypeId;
 }
 
-pub fn downcast<'a, 'r, T: Transient + 'r>(v: &'a ErasedErrorRef<'r>) -> Option<&'a T>
-    where T::Transience: CanRecoverFrom<Co<'r>>
+use sealed::Sealed;
+mod sealed {
+    use transient::{Any, Inv, TypeId};
+
+    use super::AsAny;
+
+    pub trait Sealed {}
+    impl<'r, T: Any<Inv<'r>>> Sealed for T { }
+    impl<'r, T: Any<Inv<'r>>> AsAny<Inv<'r>> for T {
+        fn as_any(&self) -> &dyn Any<Inv<'r>> {
+            self
+        }
+        fn trait_obj_typeid(&self) -> transient::TypeId {
+            TypeId::of::<T>()
+        }
+    }
+}
+
+/// This is the core of typed catchers. If an error type (returned by
+/// FromParam, FromRequest, FromForm, FromData, or Responder) implements
+/// this trait, it can be caught by a typed catcher. (TODO) This trait
+/// can be derived.
+pub trait Error<'r>: AsAny<Inv<'r>> + Send + Sync + 'r {
+    /// Generates a default response for this type (or forwards to a default catcher)
+    #[allow(unused_variables)]
+    fn respond_to(&self, request: &'r Request<'_>) -> Result<Response<'r>, Status> {
+        Err(Status::InternalServerError)
+    }
+    
+    /// A descriptive name of this error type. Defaults to the type name.
+    fn name(&self) -> &'static str { std::any::type_name::<Self>() }
+
+    /// The error that caused this error. Defaults to None.
+    ///
+    /// # Warning
+    /// A typed catcher will not attempt to follow the source of an error
+    /// more than once.
+    fn source(&self) -> Option<&dyn Error<'r>> { None }
+
+    /// Status code
+    fn status(&self) -> Status { Status::InternalServerError }
+}
+
+impl<'r> Error<'r> for std::convert::Infallible {  }
+impl<'r, L: Error<'r>, R: Error<'r>> Error<'r> for Either<L, R> {
+    fn respond_to(&self, request: &'r Request<'_>) -> Result<Response<'r>, Status> {
+        match self {
+            Self::Left(v) => v.respond_to(request),
+            Self::Right(v) => v.respond_to(request),
+        }
+    }
+
+    fn name(&self) -> &'static str { std::any::type_name::<Self>() }
+
+    fn source(&self) -> Option<&dyn Error<'r>> { 
+        match self {
+            Self::Left(v) => v.source(),
+            Self::Right(v) => v.source(),
+        }
+    }
+
+    fn status(&self) -> Status {
+        match self {
+            Self::Left(v) => v.status(),
+            Self::Right(v) => v.status(),
+        }
+    }
+}
+
+pub fn downcast<'a, 'r, T: Transient + 'r>(v: &'a dyn Error<'r>) -> Option<&'a T>
+    where T::Transience: CanRecoverFrom<Inv<'r>>
 {
-    v.downcast_ref()
+    v.as_any().downcast_ref()
 }
 
-/// Upcasts a value to `ErasedError`, falling back to a default if it doesn't implement
-/// `Transient`
+/// Upcasts a value to `Box<dyn Error<'r>>`, falling back to a default if it doesn't implement
+/// `Error`
 #[doc(hidden)]
 #[macro_export]
 macro_rules! resolve_typed_catcher {
@@ -25,9 +97,6 @@ macro_rules! resolve_typed_catcher {
         use $crate::catcher::resolution::{Resolve, DefaultTypeErase};
 
         Resolve::new($T).cast()
-    });
-    () => ({
-        $crate::catcher::default_error_type()
     });
 }
 
@@ -61,56 +130,56 @@ pub mod resolution {
     pub trait DefaultTypeErase<'r>: Sized {
         const SPECIALIZED: bool = false;
 
-        fn cast(self) -> ErasedError<'r> { Box::new(()) }
+        fn cast(self) -> Option<Box<dyn Error<'r>>> { None }
     }
 
     impl<'r, T: 'r> DefaultTypeErase<'r> for Resolve<'r, T> {}
 
     /// "Specialized" "implementation" of `Transient` for `T: Transient`. This is
     /// what Rust will resolve `Resolve<T>::item` to when `T: Transient`.
-    impl<'r, T: Transient + Send + Sync + 'r> Resolve<'r, T>
-        where T::Transience: CanTranscendTo<Co<'r>>
+    impl<'r, T: Error<'r> + Transient> Resolve<'r, T>
+        where T::Transience: CanTranscendTo<Inv<'r>>
     {
         pub const SPECIALIZED: bool = true;
 
-        pub fn cast(self) -> ErasedError<'r> { Box::new(self.0) }
+        pub fn cast(self) -> Option<Box<dyn Error<'r>>> { Some(Box::new(self.0))}
     }
 }
 
-#[cfg(test)]
-mod test {
-    // use std::any::TypeId;
+// #[cfg(test)]
+// mod test {
+//     // use std::any::TypeId;
 
-    use transient::{Transient, TypeId};
+//     use transient::{Transient, TypeId};
 
-    use super::resolution::{Resolve, DefaultTypeErase};
+//     use super::resolution::{Resolve, DefaultTypeErase};
 
-    struct NotAny;
-    #[derive(Transient)]
-    struct YesAny;
+//     struct NotAny;
+//     #[derive(Transient)]
+//     struct YesAny;
 
-    #[test]
-    fn check_can_determine() {
-        let not_any = Resolve::new(NotAny).cast();
-        assert_eq!(not_any.type_id(), TypeId::of::<()>());
+//     // #[test]
+//     // fn check_can_determine() {
+//     //     let not_any = Resolve::new(NotAny).cast();
+//     //     assert_eq!(not_any.type_id(), TypeId::of::<()>());
 
-        let yes_any = Resolve::new(YesAny).cast();
-        assert_ne!(yes_any.type_id(), TypeId::of::<()>());
-    }
+//     //     let yes_any = Resolve::new(YesAny).cast();
+//     //     assert_ne!(yes_any.type_id(), TypeId::of::<()>());
+//     // }
 
-    // struct HasSentinel<T>(T);
+//     // struct HasSentinel<T>(T);
 
-    // #[test]
-    // fn parent_works() {
-    //     let child = resolve!(YesASentinel, HasSentinel<YesASentinel>);
-    //     assert!(child.type_name.ends_with("YesASentinel"));
-    //     assert_eq!(child.parent.unwrap(), TypeId::of::<HasSentinel<YesASentinel>>());
-    //     assert!(child.specialized);
+//     // #[test]
+//     // fn parent_works() {
+//     //     let child = resolve!(YesASentinel, HasSentinel<YesASentinel>);
+//     //     assert!(child.type_name.ends_with("YesASentinel"));
+//     //     assert_eq!(child.parent.unwrap(), TypeId::of::<HasSentinel<YesASentinel>>());
+//     //     assert!(child.specialized);
 
-    //     let not_a_direct_sentinel = resolve!(HasSentinel<YesASentinel>);
-    //     assert!(not_a_direct_sentinel.type_name.contains("HasSentinel"));
-    //     assert!(not_a_direct_sentinel.type_name.contains("YesASentinel"));
-    //     assert!(not_a_direct_sentinel.parent.is_none());
-    //     assert!(!not_a_direct_sentinel.specialized);
-    // }
-}
+//     //     let not_a_direct_sentinel = resolve!(HasSentinel<YesASentinel>);
+//     //     assert!(not_a_direct_sentinel.type_name.contains("HasSentinel"));
+//     //     assert!(not_a_direct_sentinel.type_name.contains("YesASentinel"));
+//     //     assert!(not_a_direct_sentinel.parent.is_none());
+//     //     assert!(!not_a_direct_sentinel.specialized);
+//     // }
+// }

--- a/core/lib/src/catcher/types.rs
+++ b/core/lib/src/catcher/types.rs
@@ -38,7 +38,7 @@ pub trait TypedError<'r>: AsAny<Inv<'r>> + Send + Sync + 'r {
     /// Generates a default response for this type (or forwards to a default catcher)
     #[allow(unused_variables)]
     fn respond_to(&self, request: &'r Request<'_>) -> Result<Response<'r>, Status> {
-        Err(Status::InternalServerError)
+        Err(self.status())
     }
 
     /// A descriptive name of this error type. Defaults to the type name.
@@ -48,12 +48,10 @@ pub trait TypedError<'r>: AsAny<Inv<'r>> + Send + Sync + 'r {
     ///
     /// # Warning
     /// A typed catcher will not attempt to follow the source of an error
-    /// more than once.
+    /// more than (TODO: exact number) 5 times.
     fn source(&'r self) -> Option<&'r (dyn TypedError<'r> + 'r)> { None }
 
     /// Status code
-    // TODO: This is currently only used for errors produced by Fairings
-    // and the `Result` responder impl
     fn status(&self) -> Status { Status::InternalServerError }
 }
 
@@ -163,12 +161,6 @@ impl<'r> TypedError<'r> for rmp_serde::decode::Error {
 //     fn respond_to(&self, request: &'r Request<'_>) -> Result<Response<'r>, Status> {
 //         format!("{:?}", self.0).respond_to(request).responder_error()
 //     }
-// }
-
-// TODO: This could exist to allow more complex specialization
-// pub enum EitherError<L, R> {
-//     Left(L),
-//     Right(R),
 // }
 
 impl<'r, L, R> TypedError<'r> for Either<L, R>

--- a/core/lib/src/catcher/types.rs
+++ b/core/lib/src/catcher/types.rs
@@ -1,4 +1,6 @@
-use transient::{Any, CanRecoverFrom, Co, Transient, Downcast};
+use transient::{Any, CanRecoverFrom, Co, Downcast};
+#[doc(inline)]
+pub use transient::{Static, Transient};
 
 pub type ErasedError<'r> = Box<dyn Any<Co<'r>> + Send + Sync + 'r>;
 pub type ErasedErrorRef<'r> = dyn Any<Co<'r>> + Send + Sync + 'r;
@@ -13,19 +15,23 @@ pub fn downcast<'a, 'r, T: Transient + 'r>(v: &'a ErasedErrorRef<'r>) -> Option<
     v.downcast_ref()
 }
 
-// /// Chosen not to expose this macro, since it's pretty short and sweet
-// #[doc(hidden)]
-// #[macro_export]
-// macro_rules! resolve_typed_catcher {
-//     ($T:expr) => ({
-//         #[allow(unused_imports)]
-//         use $crate::catcher::types::Resolve;
-//
-//         Resolve::new($T).cast()
-//     })
-// }
+/// Upcasts a value to `ErasedError`, falling back to a default if it doesn't implement
+/// `Transient`
+#[doc(hidden)]
+#[macro_export]
+macro_rules! resolve_typed_catcher {
+    ($T:expr) => ({
+        #[allow(unused_imports)]
+        use $crate::catcher::resolution::{Resolve, DefaultTypeErase};
 
-// pub use resolve_typed_catcher;
+        Resolve::new($T).cast()
+    });
+    () => ({
+        $crate::catcher::default_error_type()
+    });
+}
+
+pub use resolve_typed_catcher;
 
 pub mod resolution {
     use std::marker::PhantomData;

--- a/core/lib/src/catcher/types.rs
+++ b/core/lib/src/catcher/types.rs
@@ -93,7 +93,6 @@ impl<'r, L, R> TypedError<'r> for Either<L, R>
     fn name(&self) -> &'static str { std::any::type_name::<Self>() }
 
     fn source(&'r self) -> Option<&'r (dyn TypedError<'r> + 'r)> { 
-        println!("Downcasting either");
         match self {
             Self::Left(v) => Some(v),
             Self::Right(v) => Some(v),

--- a/core/lib/src/catcher/types.rs
+++ b/core/lib/src/catcher/types.rs
@@ -1,0 +1,110 @@
+use transient::{Any, CanRecoverFrom, Co, Transient, Downcast};
+
+pub type ErasedError<'r> = Box<dyn Any<Co<'r>> + Send + Sync + 'r>;
+pub type ErasedErrorRef<'r> = dyn Any<Co<'r>> + Send + Sync + 'r;
+
+pub fn default_error_type<'r>() -> ErasedError<'r> {
+    Box::new(())
+}
+
+pub fn downcast<'a, 'r, T: Transient + 'r>(v: &'a ErasedErrorRef<'r>) -> Option<&'a T>
+    where T::Transience: CanRecoverFrom<Co<'r>>
+{
+    v.downcast_ref()
+}
+
+// /// Chosen not to expose this macro, since it's pretty short and sweet
+// #[doc(hidden)]
+// #[macro_export]
+// macro_rules! resolve_typed_catcher {
+//     ($T:expr) => ({
+//         #[allow(unused_imports)]
+//         use $crate::catcher::types::Resolve;
+//
+//         Resolve::new($T).cast()
+//     })
+// }
+
+// pub use resolve_typed_catcher;
+
+pub mod resolution {
+    use std::marker::PhantomData;
+
+    use transient::{CanTranscendTo, Transient};
+
+    use super::*;
+
+    /// The *magic*.
+    ///
+    /// `Resolve<T>::item` for `T: Transient` is `<T as Transient>::item`.
+    /// `Resolve<T>::item` for `T: !Transient` is `DefaultTypeErase::item`.
+    ///
+    /// This _must_ be used as `Resolve::<T>:item` for resolution to work. This
+    /// is a fun, static dispatch hack for "specialization" that works because
+    /// Rust prefers inherent methods over blanket trait impl methods.
+    pub struct Resolve<'r, T: 'r>(T, PhantomData<&'r ()>);
+
+    impl<'r, T: 'r> Resolve<'r, T> {
+        pub fn new(val: T) -> Self {
+            Self(val, PhantomData)
+        }
+    }
+
+    /// Fallback trait "implementing" `Transient` for all types. This is what
+    /// Rust will resolve `Resolve<T>::item` to when `T: !Transient`.
+    pub trait DefaultTypeErase<'r>: Sized {
+        const SPECIALIZED: bool = false;
+
+        fn cast(self) -> ErasedError<'r> { Box::new(()) }
+    }
+
+    impl<'r, T: 'r> DefaultTypeErase<'r> for Resolve<'r, T> {}
+
+    /// "Specialized" "implementation" of `Transient` for `T: Transient`. This is
+    /// what Rust will resolve `Resolve<T>::item` to when `T: Transient`.
+    impl<'r, T: Transient + Send + Sync + 'r> Resolve<'r, T>
+        where T::Transience: CanTranscendTo<Co<'r>>
+    {
+        pub const SPECIALIZED: bool = true;
+
+        pub fn cast(self) -> ErasedError<'r> { Box::new(self.0) }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    // use std::any::TypeId;
+
+    use transient::{Transient, TypeId};
+
+    use super::resolution::{Resolve, DefaultTypeErase};
+
+    struct NotAny;
+    #[derive(Transient)]
+    struct YesAny;
+
+    #[test]
+    fn check_can_determine() {
+        let not_any = Resolve::new(NotAny).cast();
+        assert_eq!(not_any.type_id(), TypeId::of::<()>());
+
+        let yes_any = Resolve::new(YesAny).cast();
+        assert_ne!(yes_any.type_id(), TypeId::of::<()>());
+    }
+
+    // struct HasSentinel<T>(T);
+
+    // #[test]
+    // fn parent_works() {
+    //     let child = resolve!(YesASentinel, HasSentinel<YesASentinel>);
+    //     assert!(child.type_name.ends_with("YesASentinel"));
+    //     assert_eq!(child.parent.unwrap(), TypeId::of::<HasSentinel<YesASentinel>>());
+    //     assert!(child.specialized);
+
+    //     let not_a_direct_sentinel = resolve!(HasSentinel<YesASentinel>);
+    //     assert!(not_a_direct_sentinel.type_name.contains("HasSentinel"));
+    //     assert!(not_a_direct_sentinel.type_name.contains("YesASentinel"));
+    //     assert!(not_a_direct_sentinel.parent.is_none());
+    //     assert!(!not_a_direct_sentinel.specialized);
+    // }
+}

--- a/core/lib/src/catcher/types.rs
+++ b/core/lib/src/catcher/types.rs
@@ -40,7 +40,7 @@ pub trait TypedError<'r>: AsAny<Inv<'r>> + Send + Sync + 'r {
     fn respond_to(&self, request: &'r Request<'_>) -> Result<Response<'r>, Status> {
         Err(Status::InternalServerError)
     }
-    
+
     /// A descriptive name of this error type. Defaults to the type name.
     fn name(&self) -> &'static str { std::any::type_name::<Self>() }
 
@@ -92,7 +92,7 @@ impl<'r, L, R> TypedError<'r> for Either<L, R>
 
     fn name(&self) -> &'static str { std::any::type_name::<Self>() }
 
-    fn source(&'r self) -> Option<&'r (dyn TypedError<'r> + 'r)> { 
+    fn source(&'r self) -> Option<&'r (dyn TypedError<'r> + 'r)> {
         match self {
             Self::Left(v) => Some(v),
             Self::Right(v) => Some(v),

--- a/core/lib/src/data/capped.rs
+++ b/core/lib/src/data/capped.rs
@@ -206,7 +206,7 @@ use crate::request::Request;
 
 impl<'r, 'o: 'r, T: Responder<'r, 'o>> Responder<'r, 'o> for Capped<T> {
     type Error = T::Error;
-    fn respond_to(self, request: &'r Request<'_>) -> response::Outcome<'o, Self::Error> {
+    fn respond_to(self, request: &'r Request<'_>) -> response::Result<'o, Self::Error> {
         self.value.respond_to(request)
     }
 }

--- a/core/lib/src/data/capped.rs
+++ b/core/lib/src/data/capped.rs
@@ -205,7 +205,8 @@ use crate::response::{self, Responder};
 use crate::request::Request;
 
 impl<'r, 'o: 'r, T: Responder<'r, 'o>> Responder<'r, 'o> for Capped<T> {
-    fn respond_to(self, request: &'r Request<'_>) -> response::Result<'o> {
+    type Error = T::Error;
+    fn respond_to(self, request: &'r Request<'_>) -> response::Outcome<'o, Self::Error> {
         self.value.respond_to(request)
     }
 }

--- a/core/lib/src/erased.rs
+++ b/core/lib/src/erased.rs
@@ -41,7 +41,7 @@ pub struct ErasedError<'r> {
 
 impl<'r> ErasedError<'r> {
     pub fn new() -> Self {
-        Self { error: None }        
+        Self { error: None }
     }
 
     pub fn write(&mut self, error: Option<Box<dyn TypedError<'r> + 'r>>) {
@@ -142,11 +142,12 @@ impl ErasedRequest {
         // SAFETY: At this point, ErasedRequest contains a request, which is permitted
         // to borrow from `Rocket` and `Parts`. They both have stable addresses (due to
         // `Arc` and `Box`), and the Request will be dropped first (due to drop order).
-        // SAFETY: Here, we place the `ErasedRequest` (i.e. the `Request`) behind an `Arc` (TODO: Why not Box?)
+        // SAFETY: Here, we place the `ErasedRequest` (i.e. the `Request`) behind an `Arc`
         // to ensure it has a stable address, and we again use drop order to ensure the `Request`
         // is dropped before the values that can borrow from it.
         let mut parent = Arc::new(self);
-        // SAFETY: This error is permitted to borrow from the `Request` (as well as `Rocket` and `Parts`).
+        // SAFETY: This error is permitted to borrow from the `Request` (as well as `Rocket` and
+        // `Parts`).
         let mut error = ErasedError { error: None };
         let token: T = {
             let parent: &mut ErasedRequest = Arc::get_mut(&mut parent).unwrap();

--- a/core/lib/src/erased.rs
+++ b/core/lib/src/erased.rs
@@ -121,8 +121,10 @@ impl ErasedRequest {
             let parent: &'static ErasedRequest = unsafe { transmute(parent) };
             let rocket: &Rocket<Orbit> = &parent._rocket;
             let request: &Request<'_> = &parent.request;
-            // SAFETY: error_ptr is transmuted into the same type, with the same lifetime as the request.
-            // It is kept alive by the erased response, so that the response type can borrow from it
+            // SAFETY: TODO: error_ptr is transmuted into the same type, with the
+            // same lifetime as the request.
+            // It is kept alive by the erased response, so that the response
+            // type can borrow from it
             dispatch(token, rocket, request, data, unsafe { transmute(&mut error_ptr)}).await
         };
 

--- a/core/lib/src/erased.rs
+++ b/core/lib/src/erased.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{fmt, io};
 use std::mem::transmute;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -41,6 +41,12 @@ pub struct ErasedError<'r> {
     error: Option<Pin<Box<dyn TypedError<'r> + 'r>>>,
 }
 
+impl fmt::Debug for ErasedError<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "<dyn TypedError>")
+    }
+}
+
 impl<'r> ErasedError<'r> {
     pub fn new() -> Self {
         Self { error: None }
@@ -65,7 +71,7 @@ impl<'r> ErasedError<'r> {
     }
 }
 
-// TODO: #[derive(Debug)]
+#[derive(Debug)]
 pub struct ErasedResponse {
     // XXX: SAFETY: This (dependent) field must come first due to drop order!
     response: Response<'static>,

--- a/core/lib/src/erased.rs
+++ b/core/lib/src/erased.rs
@@ -35,12 +35,40 @@ impl Drop for ErasedRequest {
     fn drop(&mut self) { }
 }
 
+pub struct ErasedError<'r> {
+    error: Option<Pin<Box<dyn TypedError<'r> + 'r>>>,
+}
+
+impl<'r> ErasedError<'r> {
+    pub fn new() -> Self {
+        Self { error: None }        
+    }
+
+    pub fn write(&mut self, error: Option<Box<dyn TypedError<'r> + 'r>>) {
+        // SAFETY: To meet the requirements of `Pin`, we never drop
+        // the inner Box. This is enforced by only allowing writing
+        // to the Option when it is None.
+        assert!(self.error.is_none());
+        if let Some(error) = error {
+            self.error = Some(unsafe { Pin::new_unchecked(error) });
+        }
+    }
+
+    pub fn is_some(&self) -> bool {
+        self.error.is_some()
+    }
+
+    pub fn get(&'r self) -> Option<&'r dyn TypedError<'r>> {
+        self.error.as_ref().map(|e| &**e)
+    }
+}
+
 // TODO: #[derive(Debug)]
 pub struct ErasedResponse {
     // XXX: SAFETY: This (dependent) field must come first due to drop order!
     response: Response<'static>,
-    // XXX: SAFETY: This (dependent) field must come first due to drop order!
-    error: Option<Box<dyn TypedError<'static> + 'static>>,
+    // XXX: SAFETY: This (dependent) field must come second due to drop order!
+    error: ErasedError<'static>,
     _request: Arc<ErasedRequest>,
 }
 
@@ -71,8 +99,13 @@ impl ErasedRequest {
         let parts: Box<Parts> = Box::new(parts);
         let request: Request<'_> = {
             let rocket: &Rocket<Orbit> = &rocket;
+            // SAFETY: The `Request` can borrow from `Rocket` because it has a stable
+            // address (due to `Arc`)  and it is kept alive by the containing
+            // `ErasedRequest`. The `Request` is always dropped before the
+            // `Arc<Rocket>` due to drop order.
             let rocket: &'static Rocket<Orbit> = unsafe { transmute(rocket) };
             let parts: &Parts = &parts;
+            // SAFETY: Same as above, but for `Box<Parts>`.
             let parts: &'static Parts = unsafe { transmute(parts) };
             constructor(rocket, parts)
         };
@@ -92,46 +125,54 @@ impl ErasedRequest {
             &'r Rocket<Orbit>,
             &'r mut Request<'x>,
             &'r mut Data<'x>,
-            &'r mut Option<Box<dyn TypedError<'r> + 'r>>,
+            &'r mut ErasedError<'r>,
         ) -> BoxFuture<'r, T>,
         dispatch: impl for<'r> FnOnce(
             T,
             &'r Rocket<Orbit>,
             &'r Request<'r>,
             Data<'r>,
-            &'r mut Option<Box<dyn TypedError<'r> + 'r>>,
+            &'r mut ErasedError<'r>,
         ) -> BoxFuture<'r, Response<'r>>,
     ) -> ErasedResponse
         where T: Send + Sync + 'static,
               D: for<'r> Into<RawStream<'r>>
     {
-        let mut error_ptr: Option<Box<dyn TypedError<'static> + 'static>> = None;
         let mut data: Data<'_> = Data::from(raw_stream);
+        // SAFETY: At this point, ErasedRequest contains a request, which is permitted
+        // to borrow from `Rocket` and `Parts`. They both have stable addresses (due to
+        // `Arc` and `Box`), and the Request will be dropped first (due to drop order).
+        // SAFETY: Here, we place the `ErasedRequest` (i.e. the `Request`) behind an `Arc` (TODO: Why not Box?)
+        // to ensure it has a stable address, and we again use drop order to ensure the `Request`
+        // is dropped before the values that can borrow from it.
         let mut parent = Arc::new(self);
+        // SAFETY: This error is permitted to borrow from the `Request` (as well as `Rocket` and `Parts`).
+        let mut error = ErasedError { error: None };
         let token: T = {
             let parent: &mut ErasedRequest = Arc::get_mut(&mut parent).unwrap();
             let rocket: &Rocket<Orbit> = &parent._rocket;
             let request: &mut Request<'_> = &mut parent.request;
             let data: &mut Data<'_> = &mut data;
-            // SAFETY: TODO: Same as below
-            preprocess(rocket, request, data, unsafe { transmute(&mut error_ptr) }).await
+            // SAFETY: As below, `error` must be reborrowed with the correct lifetimes.
+            preprocess(rocket, request, data, unsafe { transmute(&mut error) }).await
         };
 
         let parent = parent;
         let response: Response<'_> = {
             let parent: &ErasedRequest = &parent;
+            // SAFETY: This static reference is immediatly reborrowed for the correct lifetime.
+            // The Response type is permitted to borrow from the `Request`, `Rocket`, `Parts`, and
+            // `error`. All of these types have stable addresses, and will not be dropped until
+            // after Response, due to drop order.
             let parent: &'static ErasedRequest = unsafe { transmute(parent) };
             let rocket: &Rocket<Orbit> = &parent._rocket;
             let request: &Request<'_> = &parent.request;
-            // SAFETY: TODO: error_ptr is transmuted into the same type, with the
-            // same lifetime as the request.
-            // It is kept alive by the erased response, so that the response
-            // type can borrow from it
-            dispatch(token, rocket, request, data, unsafe { transmute(&mut error_ptr)}).await
+            // SAFETY: As above, `error` must be reborrowed with the correct lifetimes.
+            dispatch(token, rocket, request, data, unsafe { transmute(&mut error) }).await
         };
 
         ErasedResponse {
-            error: error_ptr,
+            error,
             _request: parent,
             response,
         }
@@ -159,9 +200,21 @@ impl ErasedResponse {
             &'a mut Response<'r>,
         ) -> Option<(T, Box<dyn IoHandler + 'r>)>
     ) -> Option<(T, ErasedIoHandler)> {
+        // SAFETY: If an error has been thrown, the `IoHandler` could
+        // technically borrow from it, so we must ensure that this is
+        // not the case. This could be handled safely by changing `error`
+        // to be an `Arc` internally, and cloning the Arc to get a copy
+        // (like `ErasedRequest`), however it's unclear this is actually
+        // useful, and we can avoid paying the cost of an `Arc`
+        if self.error.is_some() {
+            warn!("Attempting to upgrade after throwing a typed error is not supported");
+            return None;
+        }
         let parent: Arc<ErasedRequest> = self._request.clone();
         let io: Option<(T, Box<dyn IoHandler + '_>)> = {
             let parent: &ErasedRequest = &parent;
+            // SAFETY: As in other cases, the request is kept alive by the `Erased...`
+            // type.
             let parent: &'static ErasedRequest = unsafe { transmute(parent) };
             let request: &Request<'_> = &parent.request;
             constructor(request, &mut self.response)

--- a/core/lib/src/erased.rs
+++ b/core/lib/src/erased.rs
@@ -31,6 +31,8 @@ pub struct ErasedRequest {
     _parts: Box<Parts>,
 }
 
+// SAFETY: This tells dropck that the parts of ErasedRequest MUST be dropped
+// as a group (and ensures they happen in order)
 impl Drop for ErasedRequest {
     fn drop(&mut self) { }
 }
@@ -72,6 +74,8 @@ pub struct ErasedResponse {
     _request: Arc<ErasedRequest>,
 }
 
+// SAFETY: This tells dropck that the parts of ErasedResponse MUST be dropped
+// as a group (and ensures they happen in order)
 impl Drop for ErasedResponse {
     fn drop(&mut self) { }
 }
@@ -82,6 +86,8 @@ pub struct ErasedIoHandler {
     _request: Arc<ErasedRequest>,
 }
 
+// SAFETY: This tells dropck that the parts of ErasedIoHandler MUST be dropped
+// as a group (and ensures they happen in order)
 impl Drop for ErasedIoHandler {
     fn drop(&mut self) { }
 }

--- a/core/lib/src/error.rs
+++ b/core/lib/src/error.rs
@@ -5,8 +5,9 @@ use std::error::Error as StdError;
 use std::sync::Arc;
 
 use figment::Profile;
-use transient::Static;
+use transient::{Static, Transient};
 
+use crate::catcher::TypedError;
 use crate::listener::Endpoint;
 use crate::{Catcher, Ignite, Orbit, Phase, Rocket, Route};
 use crate::trace::Trace;
@@ -89,10 +90,10 @@ pub enum ErrorKind {
 impl Static for ErrorKind {}
 
 /// An error that occurs when a value was unexpectedly empty.
-#[derive(Clone, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Transient)]
 pub struct Empty;
 
-impl Static for Empty {}
+impl TypedError<'_> for Empty {}
 
 impl Error {
     #[inline(always)]

--- a/core/lib/src/error.rs
+++ b/core/lib/src/error.rs
@@ -5,6 +5,7 @@ use std::error::Error as StdError;
 use std::sync::Arc;
 
 use figment::Profile;
+use transient::Static;
 
 use crate::listener::Endpoint;
 use crate::{Catcher, Ignite, Orbit, Phase, Rocket, Route};
@@ -85,9 +86,13 @@ pub enum ErrorKind {
     Shutdown(Arc<Rocket<Orbit>>),
 }
 
+impl Static for ErrorKind {}
+
 /// An error that occurs when a value was unexpectedly empty.
 #[derive(Clone, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Empty;
+
+impl Static for Empty {}
 
 impl Error {
     #[inline(always)]

--- a/core/lib/src/fairing/info_kind.rs
+++ b/core/lib/src/fairing/info_kind.rs
@@ -64,15 +64,18 @@ impl Kind {
     /// `Kind` flag representing a request for a 'request' callback.
     pub const Request: Kind = Kind(1 << 2);
 
+    /// `Kind` flag representing a request for a 'filter_request' callback.
+    pub const RequestFilter: Kind = Kind(1 << 3);
+
     /// `Kind` flag representing a request for a 'response' callback.
-    pub const Response: Kind = Kind(1 << 3);
+    pub const Response: Kind = Kind(1 << 4);
 
     /// `Kind` flag representing a request for a 'shutdown' callback.
-    pub const Shutdown: Kind = Kind(1 << 4);
+    pub const Shutdown: Kind = Kind(1 << 5);
 
     /// `Kind` flag representing a
     /// [singleton](crate::fairing::Fairing#singletons) fairing.
-    pub const Singleton: Kind = Kind(1 << 5);
+    pub const Singleton: Kind = Kind(1 << 6);
 
     /// Returns `true` if `self` is a superset of `other`. In other words,
     /// returns `true` if all of the kinds in `other` are also in `self`.

--- a/core/lib/src/fairing/mod.rs
+++ b/core/lib/src/fairing/mod.rs
@@ -511,7 +511,7 @@ pub trait Fairing: Send + Sync + Any + 'static {
     /// ## Default Implementation
     ///
     /// The default implementation of this method does nothing.
-    async fn on_request<'r>(&self, _req: &'r mut Request<'_>, _data: &mut Data<'_>) { }
+    async fn on_request(&self, _req: &mut Request<'_>, _data: &mut Data<'_>) { }
 
     /// The request filter callback.
     ///
@@ -582,7 +582,7 @@ impl<T: Fairing + ?Sized> Fairing for std::sync::Arc<T> {
     }
 
     #[inline]
-    async fn on_request<'r>(&self, req: &'r mut Request<'_>, data: &mut Data<'_>) {
+    async fn on_request(&self, req: &mut Request<'_>, data: &mut Data<'_>) {
         (self as &T).on_request(req, data).await
     }
 

--- a/core/lib/src/fairing/mod.rs
+++ b/core/lib/src/fairing/mod.rs
@@ -51,6 +51,7 @@
 
 use std::any::Any;
 
+use crate::catcher::TypedError;
 use crate::{Rocket, Request, Response, Data, Build, Orbit};
 
 mod fairings;
@@ -501,7 +502,9 @@ pub trait Fairing: Send + Sync + Any + 'static {
     /// ## Default Implementation
     ///
     /// The default implementation of this method does nothing.
-    async fn on_request(&self, _req: &mut Request<'_>, _data: &mut Data<'_>) {}
+    async fn on_request<'r>(&self, _req: &'r mut Request<'_>, _data: &mut Data<'_>)
+        -> Result<(), Box<dyn TypedError<'r> + 'r>>
+    { Ok(()) }
 
     /// The response callback.
     ///
@@ -551,7 +554,9 @@ impl<T: Fairing + ?Sized> Fairing for std::sync::Arc<T> {
     }
 
     #[inline]
-    async fn on_request(&self, req: &mut Request<'_>, data: &mut Data<'_>) {
+    async fn on_request<'r>(&self, req: &'r mut Request<'_>, data: &mut Data<'_>)
+        -> Result<(), Box<dyn TypedError<'r> + 'r>>
+    {
         (self as &T).on_request(req, data).await
     }
 

--- a/core/lib/src/fairing/mod.rs
+++ b/core/lib/src/fairing/mod.rs
@@ -422,12 +422,12 @@ pub type Result<T = Rocket<Build>, E = Rocket<Build>> = std::result::Result<T, E
 /// // Allows a route to access the time a request was initiated.
 /// #[rocket::async_trait]
 /// impl<'r> FromRequest<'r> for StartTime {
-///     type Error = ();
+///     type Error = Status;
 ///
-///     async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, ()> {
+///     async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
 ///         match *request.local_cache(|| TimerStart(None)) {
 ///             TimerStart(Some(time)) => request::Outcome::Success(StartTime(time)),
-///             TimerStart(None) => request::Outcome::Error((Status::InternalServerError, ())),
+///             TimerStart(None) => request::Outcome::Error(Status::InternalServerError),
 ///         }
 ///     }
 /// }

--- a/core/lib/src/form/error.rs
+++ b/core/lib/src/form/error.rs
@@ -8,6 +8,7 @@ use std::net::AddrParseError;
 use std::borrow::Cow;
 
 use serde::{Serialize, ser::{Serializer, SerializeStruct}};
+use transient::Transient;
 
 use crate::http::Status;
 use crate::form::name::{NameBuf, Name};
@@ -54,7 +55,8 @@ use crate::data::ByteUnit;
 ///     Ok(i)
 /// }
 /// ```
-#[derive(Default, Debug, PartialEq, Serialize)]
+#[derive(Default, Debug, PartialEq, Serialize, Transient)]
+#[variance('v = co)] // TODO: update when Transient v0.4
 #[serde(transparent)]
 pub struct Errors<'v>(Vec<Error<'v>>);
 

--- a/core/lib/src/form/error.rs
+++ b/core/lib/src/form/error.rs
@@ -60,7 +60,14 @@ use crate::data::ByteUnit;
 #[serde(transparent)]
 pub struct Errors<'v>(Vec<Error<'v>>);
 
-impl<'r> TypedError<'r> for Errors<'r> { }
+impl<'r> TypedError<'r> for Errors<'r> {
+    fn respond_to(&self, _r: &'r crate::Request<'_>) -> Result<crate::Response<'r>, Status> {
+        Err(self.status())
+    }
+
+    // Calls inherent method impl
+    fn status(&self) -> Status { self.status() }
+}
 
 /// A form error, potentially tied to a specific form field.
 ///
@@ -146,8 +153,6 @@ pub struct Error<'v> {
     /// The entity that caused the error.
     pub entity: Entity,
 }
-
-// impl<'r> TypedError<'r> for Error<'r> { }
 
 /// The kind of form error that occurred.
 ///

--- a/core/lib/src/form/error.rs
+++ b/core/lib/src/form/error.rs
@@ -8,7 +8,6 @@ use std::net::AddrParseError;
 use std::borrow::Cow;
 
 use serde::{Serialize, ser::{Serializer, SerializeStruct}};
-use transient::Transient;
 
 use crate::http::Status;
 use crate::form::name::{NameBuf, Name};
@@ -55,8 +54,9 @@ use crate::data::ByteUnit;
 ///     Ok(i)
 /// }
 /// ```
-#[derive(Default, Debug, PartialEq, Serialize, Transient)]
-#[variance('v = co)] // TODO: update when Transient v0.4
+#[derive(Default, Debug, PartialEq, Serialize)]
+// TODO: this is invariant wrt 'v, since Cow<'a, T> is invariant wrt T.
+// We need it to be covariant wrt 'v, so we can use it as an error type.
 #[serde(transparent)]
 pub struct Errors<'v>(Vec<Error<'v>>);
 

--- a/core/lib/src/form/error.rs
+++ b/core/lib/src/form/error.rs
@@ -8,7 +8,9 @@ use std::net::AddrParseError;
 use std::borrow::Cow;
 
 use serde::{Serialize, ser::{Serializer, SerializeStruct}};
+use transient::Transient;
 
+use crate::catcher::TypedError;
 use crate::http::Status;
 use crate::form::name::{NameBuf, Name};
 use crate::data::ByteUnit;
@@ -54,11 +56,11 @@ use crate::data::ByteUnit;
 ///     Ok(i)
 /// }
 /// ```
-#[derive(Default, Debug, PartialEq, Serialize)]
-// TODO: this is invariant wrt 'v, since Cow<'a, T> is invariant wrt T.
-// We need it to be covariant wrt 'v, so we can use it as an error type.
+#[derive(Default, Debug, PartialEq, Serialize, Transient)]
 #[serde(transparent)]
 pub struct Errors<'v>(Vec<Error<'v>>);
+
+impl<'r> TypedError<'r> for Errors<'r> { }
 
 /// A form error, potentially tied to a specific form field.
 ///
@@ -133,7 +135,7 @@ pub struct Errors<'v>(Vec<Error<'v>>);
 /// | `value`  | `Option<&str>` | the erroring field's value, if known             |
 /// | `entity` | `&str`         | string representation of the erroring [`Entity`] |
 /// | `msg`    | `&str`         | concise message of the error                     |
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Transient)]
 pub struct Error<'v> {
     /// The name of the field, if it is known.
     pub name: Option<NameBuf<'v>>,
@@ -144,6 +146,8 @@ pub struct Error<'v> {
     /// The entity that caused the error.
     pub entity: Entity,
 }
+
+impl<'r> TypedError<'r> for Error<'r> { }
 
 /// The kind of form error that occurred.
 ///

--- a/core/lib/src/form/error.rs
+++ b/core/lib/src/form/error.rs
@@ -202,7 +202,6 @@ pub enum ErrorKind<'v> {
     Unknown,
     /// A custom error occurred. Status defaults to
     /// [`Status::UnprocessableEntity`] if one is not directly specified.
-    // TODO: This needs to be sync for TypedError
     Custom(Status, Box<dyn std::error::Error + Send + Sync>),
     /// An error while parsing a multipart form occurred.
     Multipart(multer::Error),

--- a/core/lib/src/form/form.rs
+++ b/core/lib/src/form/form.rs
@@ -333,7 +333,7 @@ impl<'r, T: FromForm<'r>> FromData<'r> for Form<T> {
 
         match T::finalize(context) {
             Ok(value) => Outcome::Success(Form(value)),
-            Err(e) => Outcome::Error((e.status(), e)),
+            Err(e) => Outcome::Error(e),
         }
     }
 }

--- a/core/lib/src/form/from_form_field.rs
+++ b/core/lib/src/form/from_form_field.rs
@@ -412,7 +412,7 @@ static DATE_TIME_FMT2: &[FormatItem<'_>] =
 impl<'v> FromFormField<'v> for Date {
     fn from_value(field: ValueField<'v>) -> Result<'v, Self> {
         let date = Self::parse(field.value, &DATE_FMT)
-            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send>)?;
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
 
         Ok(date)
     }
@@ -422,7 +422,7 @@ impl<'v> FromFormField<'v> for Time {
     fn from_value(field: ValueField<'v>) -> Result<'v, Self> {
         let time = Self::parse(field.value, &TIME_FMT1)
             .or_else(|_| Self::parse(field.value, &TIME_FMT2))
-            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send>)?;
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
 
         Ok(time)
     }
@@ -432,7 +432,7 @@ impl<'v> FromFormField<'v> for PrimitiveDateTime {
     fn from_value(field: ValueField<'v>) -> Result<'v, Self> {
         let dt = Self::parse(field.value, &DATE_TIME_FMT1)
             .or_else(|_| Self::parse(field.value, &DATE_TIME_FMT2))
-            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send>)?;
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
 
         Ok(dt)
     }

--- a/core/lib/src/form/parser.rs
+++ b/core/lib/src/form/parser.rs
@@ -40,7 +40,7 @@ impl<'r, 'i> Parser<'r, 'i> {
 
         match parser {
             Ok(storage) => Outcome::Success(storage),
-            Err(e) => Outcome::Error((e.status(), e.into()))
+            Err(e) => Outcome::Error(e.into())
         }
     }
 

--- a/core/lib/src/fs/named_file.rs
+++ b/core/lib/src/fs/named_file.rs
@@ -4,9 +4,8 @@ use std::ops::{Deref, DerefMut};
 
 use tokio::fs::{File, OpenOptions};
 
-use crate::outcome::try_outcome;
 use crate::request::Request;
-use crate::response::{Responder, Outcome};
+use crate::response::{Responder, Result};
 use crate::http::ContentType;
 
 /// A [`Responder`] that sends file data with a Content-Type based on its
@@ -154,15 +153,15 @@ impl NamedFile {
 /// implied by its extension, use a [`File`] directly.
 impl<'r> Responder<'r, 'static> for NamedFile {
     type Error = std::convert::Infallible;
-    fn respond_to(self, req: &'r Request<'_>) -> Outcome<'static, Self::Error> {
-        let mut response = try_outcome!(self.1.respond_to(req));
+    fn respond_to(self, req: &'r Request<'_>) -> Result<'static, Self::Error> {
+        let mut response = self.1.respond_to(req)?;
         if let Some(ext) = self.0.extension() {
             if let Some(ct) = ContentType::from_extension(&ext.to_string_lossy()) {
                 response.set_header(ct);
             }
         }
 
-        Outcome::Success(response)
+        Ok(response)
     }
 }
 

--- a/core/lib/src/fs/named_file.rs
+++ b/core/lib/src/fs/named_file.rs
@@ -6,7 +6,7 @@ use tokio::fs::{File, OpenOptions};
 
 use crate::outcome::try_outcome;
 use crate::request::Request;
-use crate::response::{self, Responder, Outcome};
+use crate::response::{Responder, Outcome};
 use crate::http::ContentType;
 
 /// A [`Responder`] that sends file data with a Content-Type based on its

--- a/core/lib/src/fs/server.rs
+++ b/core/lib/src/fs/server.rs
@@ -205,7 +205,7 @@ impl Handler for FileServer {
 
             if segments.is_empty() {
                 let file = NamedFile::open(&self.root).await;
-                return file.respond_to(req).or_forward((data, Status::NotFound));
+                return file.respond_to(req).ok().or_forward((data, Status::NotFound, None));
             } else {
                 return Outcome::forward(data, Status::NotFound);
             }
@@ -227,7 +227,8 @@ impl Handler for FileServer {
 
                     return Redirect::permanent(normal)
                         .respond_to(req)
-                        .or_forward((data, Status::InternalServerError));
+                        .ok()
+                        .or_forward((data, Status::InternalServerError, None));
                 }
 
                 if !options.contains(Options::Index) {
@@ -235,11 +236,11 @@ impl Handler for FileServer {
                 }
 
                 let index = NamedFile::open(p.join("index.html")).await;
-                index.respond_to(req).or_forward((data, Status::NotFound))
+                index.respond_to(req).ok().or_forward((data, Status::NotFound, None))
             },
             Some(p) => {
                 let file = NamedFile::open(p).await;
-                file.respond_to(req).or_forward((data, Status::NotFound))
+                file.respond_to(req).ok().or_forward((data, Status::NotFound, None))
             }
             None => Outcome::forward(data, Status::NotFound),
         }

--- a/core/lib/src/fs/server.rs
+++ b/core/lib/src/fs/server.rs
@@ -205,7 +205,7 @@ impl Handler for FileServer {
 
             if segments.is_empty() {
                 let file = NamedFile::open(&self.root).await;
-                return file.respond_to(req).ok().or_forward((data, Status::NotFound, None));
+                return file.respond_to(req).ok().or_forward((data, Box::new(Status::NotFound)));
             } else {
                 return Outcome::forward(data, Status::NotFound);
             }
@@ -228,7 +228,7 @@ impl Handler for FileServer {
                     return Redirect::permanent(normal)
                         .respond_to(req)
                         .ok()
-                        .or_forward((data, Status::InternalServerError, None));
+                        .or_forward((data, Box::new(Status::InternalServerError)));
                 }
 
                 if !options.contains(Options::Index) {
@@ -236,11 +236,11 @@ impl Handler for FileServer {
                 }
 
                 let index = NamedFile::open(p.join("index.html")).await;
-                index.respond_to(req).ok().or_forward((data, Status::NotFound, None))
+                index.respond_to(req).ok().or_forward((data, Box::new(Status::NotFound)))
             },
             Some(p) => {
                 let file = NamedFile::open(p).await;
-                file.respond_to(req).ok().or_forward((data, Status::NotFound, None))
+                file.respond_to(req).ok().or_forward((data, Box::new(Status::NotFound)))
             }
             None => Outcome::forward(data, Status::NotFound),
         }

--- a/core/lib/src/fs/temp_file.rs
+++ b/core/lib/src/fs/temp_file.rs
@@ -551,7 +551,7 @@ impl<'v> FromFormField<'v> for Capped<TempFile<'v>> {
 
 #[crate::async_trait]
 impl<'r> FromData<'r> for Capped<TempFile<'_>> {
-    type Error = io::Error;
+    type Error = (Status, io::Error);
 
     async fn from_data(req: &'r Request<'_>, data: Data<'r>) -> data::Outcome<'r, Self> {
         let has_form = |ty: &ContentType| ty.is_form_data() || ty.is_form();

--- a/core/lib/src/lifecycle.rs
+++ b/core/lib/src/lifecycle.rs
@@ -283,31 +283,17 @@ impl Rocket<Orbit> {
 
     /// Invokes the handler with `req` for catcher with status `status`.
     ///
-    /// In order of preference, invoked handler is:
-    ///   * the user's registered handler for `status`
-    ///   * the user's registered `default` handler
-    ///   * Rocket's default handler for `status`
-    ///
-    /// Return `Ok(result)` if the handler succeeded. Returns `Ok(Some(Status))`
-    /// if the handler ran to completion but failed. Returns `Ok(None)` if the
-    /// handler panicked while executing.
-    ///
-    /// # TODO: updated semantics:
-    ///
     /// Selects and invokes a specific catcher, with the following preference:
+    /// - The longest path base
     /// - Best matching error type (prefers calling `.source()` the fewest number
     ///   of times)
-    /// - The longest path base
     /// - Matching status
-    /// - The error's built-in responder (TODO: should this be before untyped catchers?)
+    /// - The error's built-in responder
     /// - If no catcher is found, Rocket's default handler is invoked
     ///
     /// Return `Ok(result)` if the handler succeeded. Returns `Ok(Some(Status))`
     /// if the handler ran to completion but failed. Returns `Ok(None)` if the
     /// handler panicked while executing.
-    ///
-    /// TODO: These semantics should (ideally) match the old semantics in the case where
-    /// `error` is `None`.
     async fn invoke_catcher<'s, 'r: 's>(
         &'s self,
         status: Status,

--- a/core/lib/src/lifecycle.rs
+++ b/core/lib/src/lifecycle.rs
@@ -108,8 +108,9 @@ impl Rocket<Orbit> {
         let mut response = if error_ptr.is_some() {
             // error_ptr is always some here, we just checked.
             self.dispatch_error(error_ptr.get().unwrap().status(), request, error_ptr.get()).await
-            // We MUST wait until we are inside this block to call `get`, since we HAVE to borrow it for `'r`.
-            // (And it's invariant, so we can't downcast the borrow to a shorter lifetime)
+            // We MUST wait until we are inside this block to call `get`, since we HAVE to borrow
+            // it for `'r`. (And it's invariant, so we can't downcast the borrow to a shorter
+            // lifetime)
         } else {
             match self.route(request, data).await {
                 Outcome::Success(response) => response,

--- a/core/lib/src/lifecycle.rs
+++ b/core/lib/src/lifecycle.rs
@@ -109,12 +109,16 @@ impl Rocket<Orbit> {
                 request._set_method(Method::Get);
                 match self.route(request, data).await {
                     Outcome::Success(response) => response,
-                    Outcome::Error((status, error)) => self.dispatch_error(status, request, error).await,
-                    Outcome::Forward((_, status, error)) => self.dispatch_error(status, request, error).await,
+                    Outcome::Error((status, error))
+                        => self.dispatch_error(status, request, error).await,
+                    Outcome::Forward((_, status, error))
+                        => self.dispatch_error(status, request, error).await,
                 }
             }
-            Outcome::Forward((_, status, error)) => self.dispatch_error(status, request, error).await,
-            Outcome::Error((status, error)) => self.dispatch_error(status, request, error).await,
+            Outcome::Forward((_, status, error))
+                => self.dispatch_error(status, request, error).await,
+            Outcome::Error((status, error))
+                => self.dispatch_error(status, request, error).await,
         };
 
         // Set the cookies. Note that error responses will only include cookies
@@ -274,7 +278,10 @@ impl Rocket<Orbit> {
     ) -> Result<Response<'r>, (Option<Status>, ErasedError<'r>)> {
         if let Some(catcher) = self.router.catch(status, req) {
             catcher.trace_info();
-            catch_handle(catcher.name.as_deref(), || catcher.handler.handle(status, req, error)).await
+            catch_handle(
+                catcher.name.as_deref(),
+                || catcher.handler.handle(status, req, error)
+            ).await
                 .map(|result| result.map_err(|(s, e)| (Some(s), e)))
                 .unwrap_or_else(|| Err((None, default_error_type())))
         } else {

--- a/core/lib/src/local/asynchronous/request.rs
+++ b/core/lib/src/local/asynchronous/request.rs
@@ -1,6 +1,5 @@
 use std::fmt;
 
-use crate::catcher::default_error_type;
 use crate::{Request, Data};
 use crate::http::{Status, Method};
 use crate::http::uri::Origin;
@@ -87,7 +86,7 @@ impl<'c> LocalRequest<'c> {
             if self.inner().uri() == invalid {
                 error!("invalid request URI: {:?}", invalid.path());
                 return LocalResponse::new(self.request, move |req| {
-                    rocket.dispatch_error(Status::BadRequest, req, default_error_type())
+                    rocket.dispatch_error(Status::BadRequest, req, None)
                 }).await
             }
         }

--- a/core/lib/src/local/asynchronous/request.rs
+++ b/core/lib/src/local/asynchronous/request.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use crate::lifecycle::error_ref;
 use crate::request::RequestErrors;
 use crate::{Request, Data};
 use crate::http::{Status, Method};
@@ -89,7 +90,7 @@ impl<'c> LocalRequest<'c> {
                 return LocalResponse::new(self.request, move |req, error_ptr| {
                     // TODO: Ideally the RequestErrors should contain actual information.
                     *error_ptr = Some(Box::new(RequestErrors::new(&[])));
-                    rocket.dispatch_error(Status::BadRequest, req, error_ptr.as_ref().map(|b| b.as_ref()))
+                    rocket.dispatch_error(Status::BadRequest, req, error_ref(error_ptr))
                 }).await
             }
         }

--- a/core/lib/src/local/asynchronous/request.rs
+++ b/core/lib/src/local/asynchronous/request.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use crate::request::RequestErrors;
 use crate::{Request, Data};
 use crate::http::{Status, Method};
 use crate::http::uri::Origin;
@@ -86,7 +87,8 @@ impl<'c> LocalRequest<'c> {
             if self.inner().uri() == invalid {
                 error!("invalid request URI: {:?}", invalid.path());
                 return LocalResponse::new(self.request, move |req| {
-                    rocket.dispatch_error(Status::BadRequest, req, None)
+                    // TODO: Ideally the RequestErrors should contain actual information.
+                    rocket.dispatch_error(Status::BadRequest, req, Some(Box::new(RequestErrors::new(&[]))))
                 }).await
             }
         }

--- a/core/lib/src/local/asynchronous/request.rs
+++ b/core/lib/src/local/asynchronous/request.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use crate::catcher::default_error_type;
 use crate::{Request, Data};
 use crate::http::{Status, Method};
 use crate::http::uri::Origin;
@@ -86,7 +87,7 @@ impl<'c> LocalRequest<'c> {
             if self.inner().uri() == invalid {
                 error!("invalid request URI: {:?}", invalid.path());
                 return LocalResponse::new(self.request, move |req| {
-                    rocket.dispatch_error(Status::BadRequest, req)
+                    rocket.dispatch_error(Status::BadRequest, req, default_error_type())
                 }).await
             }
         }

--- a/core/lib/src/mtls/certificate.rs
+++ b/core/lib/src/mtls/certificate.rs
@@ -112,15 +112,10 @@ impl<'r> FromRequest<'r> for Certificate<'r> {
     type Error = Error;
 
     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
-        use crate::outcome::{try_outcome, IntoOutcome};
-
-        let certs = req.connection
-            .peer_certs
-            .as_ref()
-            .or_forward(Status::Unauthorized);
-
-        let chain = try_outcome!(certs);
-        Certificate::parse(chain.inner()).or_error(Status::Unauthorized)
+        match req.connection.peer_certs.as_ref() {
+            Some(chain) => Certificate::parse(chain.inner()).into(),
+            None => Outcome::Forward(Status::Unauthorized),
+        }
     }
 }
 

--- a/core/lib/src/mtls/error.rs
+++ b/core/lib/src/mtls/error.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::num::NonZeroUsize;
 
 use crate::mtls::x509::{self, nom};
+use transient::Static;
 
 /// An error returned by the [`Certificate`](crate::mtls::Certificate) guard.
 ///
@@ -40,6 +41,8 @@ pub enum Error {
     /// The certificate contained `.0` bytes of trailing data.
     Trailing(usize),
 }
+
+impl Static for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/core/lib/src/mtls/error.rs
+++ b/core/lib/src/mtls/error.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 use std::num::NonZeroUsize;
 
-use crate::mtls::x509::{self, nom};
+use crate::http::Status;
+use crate::{catcher::TypedError, mtls::x509::{self, nom}};
 use transient::Static;
 
 /// An error returned by the [`Certificate`](crate::mtls::Certificate) guard.
@@ -43,6 +44,16 @@ pub enum Error {
 }
 
 impl Static for Error {}
+
+impl<'r> TypedError<'r> for Error {
+    fn respond_to(&self, _r: &'r crate::Request<'_>) -> Result<crate::Response<'r>, Status> {
+        Err(Status::Unauthorized)
+    }
+
+    fn source(&'r self) -> Option<&'r (dyn TypedError<'r> + 'r)> { None }
+
+    fn status(&self) -> Status { Status::Unauthorized }
+}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/core/lib/src/outcome.rs
+++ b/core/lib/src/outcome.rs
@@ -805,7 +805,7 @@ impl<'r, 'o: 'r> IntoOutcome<route::Outcome<'r>> for response::Result<'o> {
     fn or_forward(self, (data, forward): (Data<'r>, Status)) -> route::Outcome<'r> {
         match self {
             Ok(val) => Success(val),
-            Err(_) => Forward((data, forward))
+            Err(_) => Forward((data, forward, default_error_type()))
         }
     }
 }

--- a/core/lib/src/outcome.rs
+++ b/core/lib/src/outcome.rs
@@ -86,6 +86,7 @@
 //! a type of `Option<S>`. If an `Outcome` is a `Forward`, the `Option` will be
 //! `None`.
 
+use crate::catcher::default_error_type;
 use crate::{route, request, response};
 use crate::data::{self, Data, FromData};
 use crate::http::Status;
@@ -796,7 +797,7 @@ impl<'r, 'o: 'r> IntoOutcome<route::Outcome<'r>> for response::Result<'o> {
     fn or_error(self, _: ()) -> route::Outcome<'r> {
         match self {
             Ok(val) => Success(val),
-            Err(status) => Error(status),
+            Err(status) => Error((status, default_error_type())),
         }
     }
 

--- a/core/lib/src/outcome.rs
+++ b/core/lib/src/outcome.rs
@@ -86,9 +86,7 @@
 //! a type of `Option<S>`. If an `Outcome` is a `Forward`, the `Option` will be
 //! `None`.
 
-use transient::{CanTranscendTo, Co, Transient};
-
-use crate::{route, request, response};
+use crate::request;
 use crate::data::{self, Data, FromData};
 use crate::http::Status;
 
@@ -623,6 +621,20 @@ impl<S, E, F> Outcome<S, E, F> {
             _ => None,
         }
     }
+}
+
+impl<S, F> Outcome<S, std::convert::Infallible, F> {
+    /// Convenience function to convert the error type from `Infallible`
+    /// to any other type. This is trivially possible, since `Infallible`
+    /// cannot be constructed, so this cannot be an Error variant
+    pub(crate) fn map_err_type<T>(self) -> Outcome<S, T, F> {
+        match self {
+            Self::Success(v) => Outcome::Success(v),
+            Self::Forward(v) => Outcome::Forward(v),
+            Self::Error(e) => match e {},
+        }
+    }
+
 }
 
 impl<'a, S: Send + 'a, E: Send + 'a, F: Send + 'a> Outcome<S, E, F> {

--- a/core/lib/src/outcome.rs
+++ b/core/lib/src/outcome.rs
@@ -638,9 +638,8 @@ impl<S, F> Outcome<S, std::convert::Infallible, F> {
 }
 
 impl<'r, S, E: TypedError<'r>> Outcome<S, E, Status> {
-    /// Convenience function to convert the error type from `Infallible`
-    /// to any other type. This is trivially possible, since `Infallible`
-    /// cannot be constructed, so this cannot be an Error variant
+    /// Convenience function to convert the outcome from a Responder impl to
+    /// the result used by TypedError
     pub fn responder_error(self) -> Result<S, Status> {
         match self {
             Self::Success(v) => Ok(v),

--- a/core/lib/src/request/from_param.rs
+++ b/core/lib/src/request/from_param.rs
@@ -249,7 +249,7 @@ impl<'a, T: TypedError<'a>> TypedError<'a> for FromParamError<'a, T>
     }
 
     fn status(&self) -> Status {
-        self.error.status()
+        Status::UnprocessableEntity
     }
 }
 
@@ -432,7 +432,7 @@ impl<'a, T: TypedError<'a>> TypedError<'a> for FromSegmentsError<'a, T>
     }
 
     fn status(&self) -> Status {
-        self.error.status()
+        Status::UnprocessableEntity
     }
 }
 

--- a/core/lib/src/request/from_param.rs
+++ b/core/lib/src/request/from_param.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::str::FromStr;
 use std::path::PathBuf;
 
@@ -252,13 +253,28 @@ impl<'a, T: TypedError<'a>> TypedError<'a> for FromParamError<'a, T>
     }
 }
 
-// SAFETY: Since `T` `CanTransendTo` `Inv<'a>`, it is safe to
+// SAFETY: Since `T` (and &'a str) `CanTransendTo` `Inv<'a>`, it is safe to
 // transend `FromParamError<'a, T>` to `Inv<'a>`
 unsafe impl<'a, T: Transient + 'a> Transient for FromParamError<'a, T>
     where T::Transience: CanTranscendTo<Inv<'a>>,
 {
     type Static = FromParamError<'static, T::Static>;
     type Transience = Inv<'a>;
+}
+
+impl<'a, T: fmt::Debug> fmt::Debug for FromParamError<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FromParamError")
+            .field("raw", &self.raw)
+            .field("error", &self.error)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a, T: fmt::Display> fmt::Display for FromParamError<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.error.fmt(f)
+    }
 }
 
 impl<'a> FromParam<'a> for &'a str {
@@ -403,6 +419,7 @@ impl<'a, T> FromSegmentsError<'a, T> {
     }
 }
 
+
 impl<'a, T: TypedError<'a>> TypedError<'a> for FromSegmentsError<'a, T>
     where Self: Transient<Transience = Inv<'a>>
 {
@@ -419,13 +436,28 @@ impl<'a, T: TypedError<'a>> TypedError<'a> for FromSegmentsError<'a, T>
     }
 }
 
-// SAFETY: Since `T` `CanTransendTo` `Inv<'a>`, it is safe to
+// SAFETY: Since `T` (and Segments<'a, Path>) `CanTransendTo` `Inv<'a>`, it is safe to
 // transend `FromSegmentsError<'a, T>` to `Inv<'a>`
 unsafe impl<'a, T: Transient + 'a> Transient for FromSegmentsError<'a, T>
     where T::Transience: CanTranscendTo<Inv<'a>>,
 {
     type Static = FromParamError<'static, T::Static>;
     type Transience = Inv<'a>;
+}
+
+impl<'a, T: fmt::Debug> fmt::Debug for FromSegmentsError<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FromSegmentsError")
+            .field("raw", &self.raw)
+            .field("error", &self.error)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a, T: fmt::Display> fmt::Display for FromSegmentsError<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.error.fmt(f)
+    }
 }
 
 impl<'r> FromSegments<'r> for Segments<'r, Path> {

--- a/core/lib/src/request/from_request.rs
+++ b/core/lib/src/request/from_request.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 use std::convert::Infallible;
 use std::net::{IpAddr, SocketAddr};
 
+use crate::catcher::TypedError;
 use crate::{Request, Route};
 use crate::outcome::{self, IntoOutcome, Outcome::*};
 
@@ -35,7 +36,7 @@ pub type Outcome<S, E> = outcome::Outcome<S, E, Status>;
 /// ```rust
 /// use rocket::request::{self, Request, FromRequest};
 /// # struct MyType;
-/// # type MyError = String;
+/// # type MyError = std::convert::Infallible;
 ///
 /// #[rocket::async_trait]
 /// impl<'r> FromRequest<'r> for MyType {
@@ -382,7 +383,7 @@ pub type Outcome<S, E> = outcome::Outcome<S, E, Status>;
 #[crate::async_trait]
 pub trait FromRequest<'r>: Sized {
     /// The associated error to be returned if derivation fails.
-    type Error: Debug;
+    type Error: TypedError<'r> + Debug;
 
     /// Derives an instance of `Self` from the incoming request metadata.
     ///

--- a/core/lib/src/request/mod.rs
+++ b/core/lib/src/request/mod.rs
@@ -10,7 +10,8 @@ mod tests;
 
 pub use self::request::{Request, RequestErrors};
 pub use self::from_request::{FromRequest, Outcome};
-pub use self::from_param::{FromParam, FromSegments};
+pub use self::from_param::{FromParam, FromParamError};
+pub use self::from_param::{FromSegments, FromSegmentsError};
 
 #[doc(inline)]
 pub use crate::response::flash::FlashMessage;

--- a/core/lib/src/request/mod.rs
+++ b/core/lib/src/request/mod.rs
@@ -8,7 +8,7 @@ mod atomic_method;
 #[cfg(test)]
 mod tests;
 
-pub use self::request::Request;
+pub use self::request::{Request, RequestErrors};
 pub use self::from_request::{FromRequest, Outcome};
 pub use self::from_param::{FromParam, FromSegments};
 

--- a/core/lib/src/request/request.rs
+++ b/core/lib/src/request/request.rs
@@ -16,8 +16,8 @@ use crate::request::{FromParam, FromSegments, FromRequest, Outcome, AtomicMethod
 use crate::form::{self, ValueField, FromForm};
 use crate::data::Limits;
 
-use crate::http::ProxyProto;
-use crate::http::{Method, Header, HeaderMap, ContentType, Accept, MediaType, CookieJar, Cookie, Status};
+use crate::http::{Method, Header, HeaderMap, ContentType, Accept, MediaType, CookieJar, Cookie,
+    ProxyProto, Status};
 use crate::http::uri::{fmt::Path, Origin, Segments, Host, Authority};
 use crate::listener::{Certificates, Endpoint};
 

--- a/core/lib/src/response/content.rs
+++ b/core/lib/src/response/content.rs
@@ -31,7 +31,6 @@
 //! let response = content::RawHtml("<h1>Hello, world!</h1>");
 //! ```
 
-use crate::outcome::try_outcome;
 use crate::request::Request;
 use crate::response::{self, Response, Responder};
 use crate::http::ContentType;
@@ -60,7 +59,7 @@ macro_rules! ctrs {
             /// remainder of the response to the wrapped responder.
             impl<'r, 'o: 'r, R: Responder<'r, 'o>> Responder<'r, 'o> for $name<R> {
                 type Error = R::Error;
-                fn respond_to(self, req: &'r Request<'_>) -> response::Outcome<'o, Self::Error> {
+                fn respond_to(self, req: &'r Request<'_>) -> response::Result<'o, Self::Error> {
                     (ContentType::$ct, self.0).respond_to(req)
                 }
             }
@@ -81,9 +80,9 @@ ctrs! {
 
 impl<'r, 'o: 'r, R: Responder<'r, 'o>> Responder<'r, 'o> for (ContentType, R) {
     type Error = R::Error;
-    fn respond_to(self, req: &'r Request<'_>) -> response::Outcome<'o, Self::Error> {
+    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'o, Self::Error> {
         Response::build()
-            .merge(try_outcome!(self.1.respond_to(req)))
+            .merge(self.1.respond_to(req)?)
             .header(self.0)
             .ok()
     }

--- a/core/lib/src/response/debug.rs
+++ b/core/lib/src/response/debug.rs
@@ -1,3 +1,5 @@
+use transient::Static;
+
 use crate::request::Request;
 use crate::response::{self, Responder};
 use crate::http::Status;
@@ -29,6 +31,7 @@ use crate::http::Status;
 /// Because of the generic `From<E>` implementation for `Debug<E>`, conversions
 /// from `Result<T, E>` to `Result<T, Debug<E>>` through `?` occur
 /// automatically:
+/// TODO: this has changed
 ///
 /// ```rust
 /// use std::string::FromUtf8Error;
@@ -37,7 +40,7 @@ use crate::http::Status;
 /// use rocket::response::Debug;
 ///
 /// #[get("/")]
-/// fn rand_str() -> Result<String, Debug<FromUtf8Error>> {
+/// fn rand_str() -> Result<String, FromUtf8Error> {
 ///     # /*
 ///     let bytes: Vec<u8> = random_bytes();
 ///     # */
@@ -56,16 +59,18 @@ use crate::http::Status;
 /// use rocket::response::Debug;
 ///
 /// #[get("/")]
-/// fn rand_str() -> Result<String, Debug<FromUtf8Error>> {
+/// fn rand_str() -> Result<String, FromUtf8Error> {
 ///     # /*
 ///     let bytes: Vec<u8> = random_bytes();
 ///     # */
 ///     # let bytes: Vec<u8> = vec![];
-///     String::from_utf8(bytes).map_err(Debug)
+///     String::from_utf8(bytes)
 /// }
 /// ```
 #[derive(Debug)]
 pub struct Debug<E>(pub E);
+
+impl<E: 'static> Static for Debug<E> {}
 
 impl<E> From<E> for Debug<E> {
     #[inline(always)]

--- a/core/lib/src/response/debug.rs
+++ b/core/lib/src/response/debug.rs
@@ -75,17 +75,19 @@ impl<E> From<E> for Debug<E> {
 }
 
 impl<'r, E: std::fmt::Debug> Responder<'r, 'static> for Debug<E> {
-    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'static> {
+    type Error = std::convert::Infallible;
+    fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'static, Self::Error> {
         let type_name = std::any::type_name::<E>();
         info!(type_name, value = ?self.0, "debug response (500)");
-        Err(Status::InternalServerError)
+        response::Outcome::Forward(Status::InternalServerError)
     }
 }
 
 /// Prints a warning with the error and forwards to the `500` error catcher.
 impl<'r> Responder<'r, 'static> for std::io::Error {
-    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'static> {
+    type Error = std::convert::Infallible;
+    fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'static, Self::Error> {
         warn!("i/o error response: {self}");
-        Err(Status::InternalServerError)
+        response::Outcome::Forward(Status::InternalServerError)
     }
 }

--- a/core/lib/src/response/debug.rs
+++ b/core/lib/src/response/debug.rs
@@ -80,19 +80,19 @@ impl<E> From<E> for Debug<E> {
 }
 
 impl<'r, E: std::fmt::Debug> Responder<'r, 'static> for Debug<E> {
-    type Error = std::convert::Infallible;
-    fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'static, Self::Error> {
+    type Error = Status;
+    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'static, Self::Error> {
         let type_name = std::any::type_name::<E>();
         info!(type_name, value = ?self.0, "debug response (500)");
-        response::Outcome::Forward(Status::InternalServerError)
+        Err(Status::InternalServerError)
     }
 }
 
 /// Prints a warning with the error and forwards to the `500` error catcher.
 impl<'r> Responder<'r, 'static> for std::io::Error {
-    type Error = std::convert::Infallible;
-    fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'static, Self::Error> {
+    type Error = std::io::Error;
+    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'static, Self::Error> {
         warn!("i/o error response: {self}");
-        response::Outcome::Forward(Status::InternalServerError)
+        Err(self)
     }
 }

--- a/core/lib/src/response/flash.rs
+++ b/core/lib/src/response/flash.rs
@@ -50,13 +50,14 @@ const FLASH_COOKIE_DELIM: char = ':';
 /// # #[macro_use] extern crate rocket;
 /// use rocket::response::{Flash, Redirect};
 /// use rocket::request::FlashMessage;
+/// use rocket::either::Either;
 ///
 /// #[post("/login/<name>")]
-/// fn login(name: &str) -> Result<&'static str, Flash<Redirect>> {
+/// fn login(name: &str) -> Either<&'static str, Flash<Redirect>> {
 ///     if name == "special_user" {
-///         Ok("Hello, special user!")
+///         Either::Left("Hello, special user!")
 ///     } else {
-///         Err(Flash::error(Redirect::to(uri!(index)), "Invalid username."))
+///         Either::Right(Flash::error(Redirect::to(uri!(index)), "Invalid username."))
 ///     }
 /// }
 ///

--- a/core/lib/src/response/flash.rs
+++ b/core/lib/src/response/flash.rs
@@ -189,7 +189,8 @@ impl<R> Flash<R> {
 /// response handling to the wrapped responder. As a result, the `Outcome` of
 /// the response is the `Outcome` of the wrapped `Responder`.
 impl<'r, 'o: 'r, R: Responder<'r, 'o>> Responder<'r, 'o> for Flash<R> {
-    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'o> {
+    type Error = R::Error;
+    fn respond_to(self, req: &'r Request<'_>) -> response::Outcome<'o, Self::Error> {
         req.cookies().add(self.cookie());
         self.inner.respond_to(req)
     }

--- a/core/lib/src/response/flash.rs
+++ b/core/lib/src/response/flash.rs
@@ -190,7 +190,7 @@ impl<R> Flash<R> {
 /// the response is the `Outcome` of the wrapped `Responder`.
 impl<'r, 'o: 'r, R: Responder<'r, 'o>> Responder<'r, 'o> for Flash<R> {
     type Error = R::Error;
-    fn respond_to(self, req: &'r Request<'_>) -> response::Outcome<'o, Self::Error> {
+    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'o, Self::Error> {
         req.cookies().add(self.cookie());
         self.inner.respond_to(req)
     }

--- a/core/lib/src/response/mod.rs
+++ b/core/lib/src/response/mod.rs
@@ -35,5 +35,7 @@ pub use self::redirect::Redirect;
 pub use self::flash::Flash;
 pub use self::debug::Debug;
 
-/// Type alias for the `Result` of a [`Responder::respond_to()`] call.
-pub type Result<'r> = std::result::Result<Response<'r>, crate::http::Status>;
+use crate::http::Status;
+
+/// Type alias for the `Outcome` of a [`Responder::respond_to()`] call.
+pub type Outcome<'o, Error> = crate::outcome::Outcome<Response<'o>, Error, Status>;

--- a/core/lib/src/response/mod.rs
+++ b/core/lib/src/response/mod.rs
@@ -35,7 +35,5 @@ pub use self::redirect::Redirect;
 pub use self::flash::Flash;
 pub use self::debug::Debug;
 
-use crate::http::Status;
-
 /// Type alias for the `Outcome` of a [`Responder::respond_to()`] call.
-pub type Outcome<'o, Error> = crate::outcome::Outcome<Response<'o>, Error, Status>;
+pub type Result<'o, Error> = std::result::Result<Response<'o>, Error>;

--- a/core/lib/src/response/redirect.rs
+++ b/core/lib/src/response/redirect.rs
@@ -153,8 +153,8 @@ impl Redirect {
 /// value used to create the `Responder` is an invalid URI, an error of
 /// `Status::InternalServerError` is returned.
 impl<'r> Responder<'r, 'static> for Redirect {
-    type Error = std::convert::Infallible;
-    fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'static, Self::Error> {
+    type Error = Status;
+    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'static, Self::Error> {
         if let Some(uri) = self.1 {
             Response::build()
                 .status(self.0)
@@ -162,7 +162,7 @@ impl<'r> Responder<'r, 'static> for Redirect {
                 .ok()
         } else {
             error!("Invalid URI used for redirect.");
-            response::Outcome::Forward(Status::InternalServerError)
+            Err(Status::InternalServerError)
         }
     }
 }

--- a/core/lib/src/response/redirect.rs
+++ b/core/lib/src/response/redirect.rs
@@ -151,7 +151,8 @@ impl Redirect {
 /// value used to create the `Responder` is an invalid URI, an error of
 /// `Status::InternalServerError` is returned.
 impl<'r> Responder<'r, 'static> for Redirect {
-    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'static> {
+    type Error = std::convert::Infallible;
+    fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'static, Self::Error> {
         if let Some(uri) = self.1 {
             Response::build()
                 .status(self.0)
@@ -159,7 +160,7 @@ impl<'r> Responder<'r, 'static> for Redirect {
                 .ok()
         } else {
             error!("Invalid URI used for redirect.");
-            Err(Status::InternalServerError)
+            response::Outcome::Forward(Status::InternalServerError)
         }
     }
 }

--- a/core/lib/src/response/redirect.rs
+++ b/core/lib/src/response/redirect.rs
@@ -1,6 +1,5 @@
 use transient::Transient;
 
-use crate::catcher::TypedError;
 use crate::request::Request;
 use crate::response::{self, Response, Responder};
 use crate::http::uri::Reference;
@@ -165,25 +164,5 @@ impl<'r> Responder<'r, 'static> for Redirect {
             error!("Invalid URI used for redirect.");
             response::Outcome::Forward(Status::InternalServerError)
         }
-    }
-}
-
-// TODO: This is a hack
-impl<'r> TypedError<'r> for Redirect {
-    fn respond_to(&self, _req: &'r Request<'r>) -> Result<Response<'r>, Status> {
-        if let Some(uri) = &self.1 {
-            Response::build()
-                .status(self.0)
-                .raw_header("Location", uri.to_string())
-                .ok::<()>()
-                .responder_error()
-        } else {
-            error!("Invalid URI used for redirect.");
-            Err(Status::InternalServerError)
-        }
-    }
-
-    fn status(&self) -> Status {
-        self.0
     }
 }

--- a/core/lib/src/response/responder.rs
+++ b/core/lib/src/response/responder.rs
@@ -304,6 +304,8 @@ use super::Outcome;
 /// # fn person() -> Person { Person::new("Bob", 29) }
 /// ```
 pub trait Responder<'r, 'o: 'r> {
+    // TODO: Should this instead be something like `HasStatus`, and we specialize
+    // on whether it implements TypedError?
     type Error: TypedError<'r> + Transient;
 
     /// Returns `Ok` if a `Response` could be generated successfully. Otherwise,
@@ -317,6 +319,8 @@ pub trait Responder<'r, 'o: 'r> {
     /// returned, the error catcher for the given status is retrieved and called
     /// to generate a final error response, which is then written out to the
     /// client.
+    // TODO: This could return `Result<Response, Self::Error>`, and we could use
+    // Self::Error = Status when we want the old behavior
     fn respond_to(self, request: &'r Request<'_>) -> response::Outcome<'o, Self::Error>;
 }
 

--- a/core/lib/src/response/responder.rs
+++ b/core/lib/src/response/responder.rs
@@ -1,5 +1,4 @@
 use std::convert::Infallible;
-use std::fmt;
 use std::fs::File;
 use std::io::Cursor;
 use std::sync::Arc;

--- a/core/lib/src/response/responder.rs
+++ b/core/lib/src/response/responder.rs
@@ -199,6 +199,7 @@ use super::Outcome;
 /// # struct C;
 /// // If the response is or wraps a borrow that may outlive the request.
 /// impl<'r, 'o: 'r> Responder<'r, 'o> for &'o C {
+///     type Error = std::convert::Infallible;
 ///     fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'o, Self::Error> {
 ///         todo!()
 ///     }
@@ -207,6 +208,7 @@ use super::Outcome;
 /// # struct D<R>(R);
 /// // If the response wraps an existing responder.
 /// impl<'r, 'o: 'r, R: Responder<'r, 'o>> Responder<'r, 'o> for D<R> {
+///     type Error = std::convert::Infallible;
 ///     fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'o, Self::Error> {
 ///         todo!()
 ///     }
@@ -254,12 +256,14 @@ use super::Outcome;
 ///
 /// use rocket::request::Request;
 /// use rocket::response::{self, Response, Responder};
+/// use rocket::outcome::try_outcome;
 /// use rocket::http::ContentType;
 ///
 /// impl<'r> Responder<'r, 'static> for Person {
-///     fn respond_to(self, req: &'r Request<'_>) -> response::Result<'static> {
+///     type Error = std::convert::Infallible;
+///     fn respond_to(self, req: &'r Request<'_>) -> response::Outcome<'static, Self::Error> {
 ///         let string = format!("{}:{}", self.name, self.age);
-///         Response::build_from(string.respond_to(req)?)
+///         Response::build_from(try_outcome!(string.respond_to(req)))
 ///             .raw_header("X-Person-Name", self.name)
 ///             .raw_header("X-Person-Age", self.age.to_string())
 ///             .header(ContentType::new("application", "x-person"))

--- a/core/lib/src/response/responder.rs
+++ b/core/lib/src/response/responder.rs
@@ -498,13 +498,15 @@ impl<'r, 'o: 'r, R: ?Sized + ToOwned> Responder<'r, 'o> for std::borrow::Cow<'o,
           <<&'o R as Responder<'r, 'o>>::Error as Transient>::Transience: CanTranscendTo<Inv<'r>>,
           <R as ToOwned>::Owned: Responder<'r, 'o> + 'r,
           <<R as ToOwned>::Owned as Responder<'r, 'o>>::Error: Transient,
-          <<<R as ToOwned>::Owned as Responder<'r, 'o>>::Error as Transient>::Transience: CanTranscendTo<Inv<'r>>,
+          <<<R as ToOwned>::Owned as Responder<'r, 'o>>::Error as Transient>::Transience:
+                                              CanTranscendTo<Inv<'r>>,
+                                              // TODO: this atrocious formatting
 {
     type Error = Either<
         <&'o R as Responder<'r, 'o>>::Error,
         <R::Owned as Responder<'r, 'o>>::Error,
     >;
-    
+
     fn respond_to(self, req: &'r Request<'_>) -> response::Outcome<'o, Self::Error> {
         match self {
             std::borrow::Cow::Borrowed(b) => b.respond_to(req).map_error(|e| Either::Left(e)),

--- a/core/lib/src/response/responder.rs
+++ b/core/lib/src/response/responder.rs
@@ -537,7 +537,7 @@ impl<'r, 'o: 'r, T, E> Responder<'r, 'o> for Result<T, E>
     where T: Responder<'r, 'o>,
           T::Error: Transient,
           <T::Error as Transient>::Transience: CanTranscendTo<Inv<'r>>,
-          E: fmt::Debug + TypedError<'r> + Transient + 'r,
+          E: TypedError<'r> + Transient + 'r,
           E::Transience: CanTranscendTo<Inv<'r>>,
 {
     type Error = Either<T::Error, E>;

--- a/core/lib/src/response/response.rs
+++ b/core/lib/src/response/response.rs
@@ -9,8 +9,6 @@ use crate::http::uncased::{Uncased, AsUncased};
 use crate::data::IoHandler;
 use crate::response::Body;
 
-use super::Outcome;
-
 /// Builder for the [`Response`] type.
 ///
 /// Building a [`Response`] can be a low-level ordeal; this structure presents a
@@ -434,17 +432,17 @@ impl<'r> Builder<'r> {
     /// # Example
     ///
     /// ```rust
-    /// use rocket::response::{Response, Outcome};
+    /// use rocket::response::{Response, Result};
     ///
-    /// let response: Outcome<'_, ()> = Response::build()
+    /// let response: Result<'_, ()> = Response::build()
     ///     // build the response
     ///     .ok();
     ///
-    /// assert!(response.is_success());
+    /// assert!(response.is_ok());
     /// ```
     #[inline(always)]
-    pub fn ok<E>(&mut self) -> Outcome<'r, E> {
-        Outcome::Success(self.finalize())
+    pub fn ok<E>(&mut self) -> crate::response::Result<'r, E> {
+        Ok(self.finalize())
     }
 }
 

--- a/core/lib/src/response/response.rs
+++ b/core/lib/src/response/response.rs
@@ -436,7 +436,7 @@ impl<'r> Builder<'r> {
     /// ```rust
     /// use rocket::response::{Response, Outcome};
     ///
-    /// let response: Outcome<Response, ()> = Response::build()
+    /// let response: Outcome<'_, ()> = Response::build()
     ///     // build the response
     ///     .ok();
     ///

--- a/core/lib/src/response/response.rs
+++ b/core/lib/src/response/response.rs
@@ -9,6 +9,8 @@ use crate::http::uncased::{Uncased, AsUncased};
 use crate::data::IoHandler;
 use crate::response::Body;
 
+use super::Outcome;
+
 /// Builder for the [`Response`] type.
 ///
 /// Building a [`Response`] can be a low-level ordeal; this structure presents a
@@ -432,17 +434,17 @@ impl<'r> Builder<'r> {
     /// # Example
     ///
     /// ```rust
-    /// use rocket::Response;
+    /// use rocket::response::{Response, Outcome};
     ///
-    /// let response: Result<Response, ()> = Response::build()
+    /// let response: Outcome<Response, ()> = Response::build()
     ///     // build the response
     ///     .ok();
     ///
-    /// assert!(response.is_ok());
+    /// assert!(response.is_success());
     /// ```
     #[inline(always)]
-    pub fn ok<E>(&mut self) -> Result<Response<'r>, E> {
-        Ok(self.finalize())
+    pub fn ok<E>(&mut self) -> Outcome<'r, E> {
+        Outcome::Success(self.finalize())
     }
 }
 

--- a/core/lib/src/response/status.rs
+++ b/core/lib/src/response/status.rs
@@ -29,6 +29,9 @@ use std::hash::{Hash, Hasher};
 use std::collections::hash_map::DefaultHasher;
 use std::borrow::Cow;
 
+use transient::Static;
+
+use crate::catcher::TypedError;
 use crate::outcome::try_outcome;
 use crate::request::Request;
 use crate::response::{self, Responder, Response};
@@ -181,6 +184,14 @@ impl<'r, 'o: 'r, R: Responder<'r, 'o>> Responder<'r, 'o> for Created<R> {
     }
 }
 
+// TODO: do we want this?
+impl<R: Send + Sync + 'static> TypedError<'_> for Created<R> {
+    fn status(&self) -> Status {
+        Status::Created
+    }
+}
+impl<R: 'static> Static for Created<R> {}
+
 /// Sets the status of the response to 204 No Content.
 ///
 /// The response body will be empty.
@@ -299,6 +310,14 @@ macro_rules! status_response {
                 Custom(Status::$T, self.0).respond_to(req)
             }
         }
+
+        // TODO: do we want this?
+        impl<R: Send + Sync + 'static> TypedError<'_> for $T<R> {
+            fn status(&self) -> Status {
+                Status::$T
+            }
+        }
+        impl<R: 'static> Static for $T<R> {}
     }
 }
 

--- a/core/lib/src/response/stream/bytes.rs
+++ b/core/lib/src/response/stream/bytes.rs
@@ -65,7 +65,7 @@ impl<'r, S: Stream> Responder<'r, 'r> for ByteStream<S>
     where S: Send + 'r, S::Item: AsRef<[u8]> + Send + Unpin + 'r
 {
     type Error = std::convert::Infallible;
-    fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'r, Self::Error> {
+    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r, Self::Error> {
         Response::build()
             .header(ContentType::Binary)
             .streamed_body(ReaderStream::from(self.0.map(std::io::Cursor::new)))

--- a/core/lib/src/response/stream/bytes.rs
+++ b/core/lib/src/response/stream/bytes.rs
@@ -64,7 +64,8 @@ impl<S> From<S> for ByteStream<S> {
 impl<'r, S: Stream> Responder<'r, 'r> for ByteStream<S>
     where S: Send + 'r, S::Item: AsRef<[u8]> + Send + Unpin + 'r
 {
-    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r> {
+    type Error = std::convert::Infallible;
+    fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'r, Self::Error> {
         Response::build()
             .header(ContentType::Binary)
             .streamed_body(ReaderStream::from(self.0.map(std::io::Cursor::new)))

--- a/core/lib/src/response/stream/reader.rs
+++ b/core/lib/src/response/stream/reader.rs
@@ -40,7 +40,7 @@ pin_project! {
     ///     where S: Send + 'r
     /// {
     ///     type Error = std::convert::Infallible;
-    ///     fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'r, Self::Error> {
+    ///     fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r, Self::Error> {
     ///         Response::build()
     ///             .header(ContentType::Text)
     ///             .streamed_body(ReaderStream::from(self.0.map(Cursor::new)))
@@ -144,7 +144,7 @@ impl<'r, S: Stream> Responder<'r, 'r> for ReaderStream<S>
     where S: Send + 'r, S::Item: AsyncRead + Send,
 {
     type Error = std::convert::Infallible;
-    fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'r, Self::Error> {
+    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r, Self::Error> {
         Response::build()
             .streamed_body(self)
             .ok()

--- a/core/lib/src/response/stream/reader.rs
+++ b/core/lib/src/response/stream/reader.rs
@@ -39,7 +39,8 @@ pin_project! {
     /// impl<'r, S: Stream<Item = String>> Responder<'r, 'r> for MyStream<S>
     ///     where S: Send + 'r
     /// {
-    ///     fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r> {
+    ///     type Error = std::convert::Infallible;
+    ///     fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'r, Self::Error> {
     ///         Response::build()
     ///             .header(ContentType::Text)
     ///             .streamed_body(ReaderStream::from(self.0.map(Cursor::new)))

--- a/core/lib/src/response/stream/reader.rs
+++ b/core/lib/src/response/stream/reader.rs
@@ -142,7 +142,8 @@ impl<S: Stream> From<S> for ReaderStream<S> {
 impl<'r, S: Stream> Responder<'r, 'r> for ReaderStream<S>
     where S: Send + 'r, S::Item: AsyncRead + Send,
 {
-    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r> {
+    type Error = std::convert::Infallible;
+    fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'r, Self::Error> {
         Response::build()
             .streamed_body(self)
             .ok()

--- a/core/lib/src/response/stream/sse.rs
+++ b/core/lib/src/response/stream/sse.rs
@@ -569,7 +569,8 @@ impl<S: Stream<Item = Event>> From<S> for EventStream<S> {
 }
 
 impl<'r, S: Stream<Item = Event> + Send + 'r> Responder<'r, 'r> for EventStream<S> {
-    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r> {
+    type Error = std::convert::Infallible;
+    fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'r, Self::Error> {
         Response::build()
             .header(ContentType::EventStream)
             .raw_header("Cache-Control", "no-cache")

--- a/core/lib/src/response/stream/sse.rs
+++ b/core/lib/src/response/stream/sse.rs
@@ -570,7 +570,7 @@ impl<S: Stream<Item = Event>> From<S> for EventStream<S> {
 
 impl<'r, S: Stream<Item = Event> + Send + 'r> Responder<'r, 'r> for EventStream<S> {
     type Error = std::convert::Infallible;
-    fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'r, Self::Error> {
+    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r, Self::Error> {
         Response::build()
             .header(ContentType::EventStream)
             .raw_header("Cache-Control", "no-cache")

--- a/core/lib/src/response/stream/text.rs
+++ b/core/lib/src/response/stream/text.rs
@@ -66,7 +66,7 @@ impl<'r, S: Stream> Responder<'r, 'r> for TextStream<S>
     where S: Send + 'r, S::Item: AsRef<str> + Send + Unpin + 'r
 {
     type Error = std::convert::Infallible;
-    fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'r, Self::Error> {
+    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r, Self::Error> {
         struct ByteStr<T>(T);
 
         impl<T: AsRef<str>> AsRef<[u8]> for ByteStr<T> {

--- a/core/lib/src/response/stream/text.rs
+++ b/core/lib/src/response/stream/text.rs
@@ -65,7 +65,8 @@ impl<S> From<S> for TextStream<S> {
 impl<'r, S: Stream> Responder<'r, 'r> for TextStream<S>
     where S: Send + 'r, S::Item: AsRef<str> + Send + Unpin + 'r
 {
-    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r> {
+    type Error = std::convert::Infallible;
+    fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'r, Self::Error> {
         struct ByteStr<T>(T);
 
         impl<T: AsRef<str>> AsRef<[u8]> for ByteStr<T> {

--- a/core/lib/src/rocket.rs
+++ b/core/lib/src/rocket.rs
@@ -379,7 +379,7 @@ impl Rocket<Build> {
     ///
     /// ```rust,no_run
     /// # #[macro_use] extern crate rocket;
-    /// use rocket::Request;
+    /// use rocket::http::uri::Origin;
     ///
     /// #[catch(500)]
     /// fn internal_error() -> &'static str {
@@ -387,8 +387,8 @@ impl Rocket<Build> {
     /// }
     ///
     /// #[catch(404)]
-    /// fn not_found(req: &Request) -> String {
-    ///     format!("I couldn't find '{}'. Try something else?", req.uri())
+    /// fn not_found(uri: &Origin) -> String {
+    ///     format!("I couldn't find '{}'. Try something else?", uri)
     /// }
     ///
     /// #[launch]

--- a/core/lib/src/route/handler.rs
+++ b/core/lib/src/route/handler.rs
@@ -261,8 +261,12 @@ impl<'r, 'o: 'r> Outcome<'o> {
     /// use rocket::{Request, Data, route};
     /// use rocket::http::Status;
     ///
+    /// struct CustomError(&'static str);
+    /// impl rocket::catcher::Static for CustomError {}
+    /// impl rocket::catcher::TypedError<'_> for CustomError {}
+    ///
     /// fn bad_req_route<'r>(_: &'r Request, _: Data<'r>) -> route::Outcome<'r> {
-    ///     route::Outcome::error_val(Status::BadRequest, "Some data to go with")
+    ///     route::Outcome::error_val(Status::BadRequest, CustomError("Some data to go with"))
     /// }
     /// ```
     #[inline(always)]

--- a/core/lib/src/route/handler.rs
+++ b/core/lib/src/route/handler.rs
@@ -7,7 +7,11 @@ use crate::http::Status;
 
 /// Type alias for the return type of a [`Route`](crate::Route)'s
 /// [`Handler::handle()`].
-pub type Outcome<'r> = crate::outcome::Outcome<Response<'r>, (Status, ErasedError<'r>), (Data<'r>, Status, ErasedError<'r>)>;
+pub type Outcome<'r> = crate::outcome::Outcome<
+    Response<'r>,
+    (Status, ErasedError<'r>),
+    (Data<'r>, Status, ErasedError<'r>)
+>;
 
 /// Type alias for the return type of a _raw_ [`Route`](crate::Route)'s
 /// [`Handler`].
@@ -240,7 +244,7 @@ impl<'r, 'o: 'r> Outcome<'o> {
         Outcome::Error((code, Box::new(())))
     }
     /// Return an `Outcome` of `Error` with the status code `code`. This adds
-    /// the 
+    /// the value for typed catchers.
     ///
     /// This method exists to be used during manual routing.
     ///
@@ -295,7 +299,9 @@ impl<'r, 'o: 'r> Outcome<'o> {
     /// }
     /// ```
     #[inline(always)]
-    pub fn forward_val<T: Any<Co<'r>> + Send + Sync + 'r>(data: Data<'r>, status: Status, val: T) -> Outcome<'r> {
+    pub fn forward_val<T: Any<Co<'r>> + Send + Sync + 'r>(data: Data<'r>, status: Status, val: T)
+        -> Outcome<'r>
+    {
         Outcome::Forward((data, status, Box::new(val)))
     }
 }

--- a/core/lib/src/route/handler.rs
+++ b/core/lib/src/route/handler.rs
@@ -194,7 +194,10 @@ impl<'r, 'o: 'r> Outcome<'o> {
         match responder.respond_to(req) {
             response::Outcome::Success(response) => Outcome::Success(response),
             response::Outcome::Error(error) => {
-                crate::trace::info!(type_name = std::any::type_name_of_val(&error), "Typed error to catch");
+                crate::trace::info!(
+                    type_name = std::any::type_name_of_val(&error),
+                    "Typed error to catch"
+                );
                 Outcome::Error((error.status(), Some(Box::new(error))))
             },
             response::Outcome::Forward(status) => Outcome::Error((status, None)),

--- a/core/lib/src/route/handler.rs
+++ b/core/lib/src/route/handler.rs
@@ -175,10 +175,8 @@ impl<F: Clone + Sync + Send + 'static> Handler for F
 impl<'r, 'o: 'r> Outcome<'o> {
     /// Return the `Outcome` of response to `req` from `responder`.
     ///
-    // TODO: docs
-    /// If the responder returns `Ok`, an outcome of `Success` is returned with
-    /// the response. If the responder returns `Err`, an outcome of `Error` is
-    /// returned with the status code.
+    /// Converts both Forwards and Errors to Errors, with the same status,
+    /// (and the appropriate error type).
     ///
     /// # Example
     ///
@@ -203,33 +201,6 @@ impl<'r, 'o: 'r> Outcome<'o> {
             response::Outcome::Forward(status) => Outcome::Error((status, None)),
         }
     }
-
-    // TODO: does this still make sense
-    // /// Return the `Outcome` of response to `req` from `responder`.
-    // ///
-    // /// If the responder returns `Ok`, an outcome of `Success` is returned with
-    // /// the response. If the responder returns `Err`, an outcome of `Error` is
-    // /// returned with the status code.
-    // ///
-    // /// # Example
-    // ///
-    // /// ```rust
-    // /// use rocket::{Request, Data, route};
-    // ///
-    // /// fn str_responder<'r>(req: &'r Request, _: Data<'r>) -> route::Outcome<'r> {
-    // ///     route::Outcome::from(req, "Hello, world!")
-    // /// }
-    // /// ```
-    // #[inline]
-    // pub fn try_from<R, E>(req: &'r Request<'_>, result: Result<R, E>) -> Outcome<'r>
-    //     where R: Responder<'r, 'o>, E: std::fmt::Debug
-    // {
-    //     let responder = result.map_err(crate::response::Debug);
-    //     match responder.respond_to(req) {
-    //         Ok(response) => Outcome::Success(response),
-    //         Err(status) => Outcome::Error((status, Box::new(()))),
-    //     }
-    // }
 
     /// Return an `Outcome` of `Error` with the status code `code`. This is
     /// equivalent to `Outcome::error_val(code, ())`.

--- a/core/lib/src/route/handler.rs
+++ b/core/lib/src/route/handler.rs
@@ -2,7 +2,7 @@ use transient::{CanTranscendTo, Inv, Transient};
 
 use crate::catcher::TypedError;
 use crate::{Request, Data};
-use crate::response::{self, Response, Responder};
+use crate::response::{Response, Responder};
 use crate::http::Status;
 
 /// Type alias for the return type of a [`Route`](crate::Route)'s
@@ -192,17 +192,17 @@ impl<'r, 'o: 'r> Outcome<'o> {
     #[inline]
     pub fn from<R: Responder<'r, 'o>>(req: &'r Request<'_>, responder: R) -> Outcome<'r> {
         match responder.respond_to(req) {
-            response::Outcome::Success(response) => Outcome::Success(response),
-            response::Outcome::Error(error) => {
+            Ok(response) => Outcome::Success(response),
+            Err(error) => {
                 crate::trace::info!(
                     type_name = std::any::type_name_of_val(&error),
                     "Typed error to catch"
                 );
                 Outcome::Error(Box::new(error))
             },
-            response::Outcome::Forward(status) => {
-                Outcome::Error(Box::new(status) as Box<dyn TypedError<'r>>)
-            }
+            // response::Outcome::Forward(status) => {
+            //     Outcome::Error(Box::new(status) as Box<dyn TypedError<'r>>)
+            // }
         }
     }
 

--- a/core/lib/src/route/handler.rs
+++ b/core/lib/src/route/handler.rs
@@ -1,4 +1,4 @@
-use crate::catcher::Error;
+use crate::catcher::TypedError;
 use crate::{Request, Data};
 use crate::response::{self, Response, Responder};
 use crate::http::Status;
@@ -7,8 +7,8 @@ use crate::http::Status;
 /// [`Handler::handle()`].
 pub type Outcome<'r> = crate::outcome::Outcome<
     Response<'r>,
-    (Status, Option<Box<dyn Error<'r>>>),
-    (Data<'r>, Status, Option<Box<dyn Error<'r>>>)
+    (Status, Option<Box<dyn TypedError<'r>>>),
+    (Data<'r>, Status, Option<Box<dyn TypedError<'r>>>)
 >;
 
 /// Type alias for the return type of a _raw_ [`Route`](crate::Route)'s
@@ -193,7 +193,10 @@ impl<'r, 'o: 'r> Outcome<'o> {
     pub fn from<R: Responder<'r, 'o>>(req: &'r Request<'_>, responder: R) -> Outcome<'r> {
         match responder.respond_to(req) {
             response::Outcome::Success(response) => Outcome::Success(response),
-            response::Outcome::Error(error) => Outcome::Error((error.status(), Some(Box::new(error)))),
+            response::Outcome::Error(error) => {
+                crate::trace::info!(type_name = std::any::type_name_of_val(&error), "Typed error to catch");
+                Outcome::Error((error.status(), Some(Box::new(error))))
+            },
             response::Outcome::Forward(status) => Outcome::Error((status, None)),
         }
     }
@@ -260,7 +263,7 @@ impl<'r, 'o: 'r> Outcome<'o> {
     /// }
     /// ```
     #[inline(always)]
-    pub fn error_val<T: Error<'r>>(code: Status, val: T) -> Outcome<'r> {
+    pub fn error_val<T: TypedError<'r>>(code: Status, val: T) -> Outcome<'r> {
         Outcome::Error((code, Some(Box::new(val))))
     }
 
@@ -300,7 +303,7 @@ impl<'r, 'o: 'r> Outcome<'o> {
     /// }
     /// ```
     #[inline(always)]
-    pub fn forward_val<T: Error<'r>>(data: Data<'r>, status: Status, val: T)
+    pub fn forward_val<T: TypedError<'r>>(data: Data<'r>, status: Status, val: T)
         -> Outcome<'r>
     {
         Outcome::Forward((data, status, Some(Box::new(val))))

--- a/core/lib/src/router/collider.rs
+++ b/core/lib/src/router/collider.rs
@@ -210,7 +210,7 @@ fn formats_collide(route: &Route, other: &Route) -> bool {
 }
 
 fn types_collide(catcher: &Catcher, other: &Catcher) -> bool {
-    catcher.error_type.as_ref().map(|(i, _)| i) == other.error_type.as_ref().map(|(i, _)| i) 
+    catcher.error_type.as_ref().map(|(i, _)| i) == other.error_type.as_ref().map(|(i, _)| i)
 }
 
 #[cfg(test)]

--- a/core/lib/src/router/collider.rs
+++ b/core/lib/src/router/collider.rs
@@ -141,7 +141,9 @@ impl Catcher {
     /// assert!(!a.collides_with(&b));
     /// ```
     pub fn collides_with(&self, other: &Self) -> bool {
-        self.code == other.code && self.base().segments().eq(other.base().segments())
+        self.code == other.code &&
+            types_collide(self, other) &&
+            self.base().segments().eq(other.base().segments())
     }
 }
 
@@ -205,6 +207,10 @@ fn formats_collide(route: &Route, other: &Route) -> bool {
         // would match any format. Thus two such routes would always collide.
         _ => true,
     }
+}
+
+fn types_collide(catcher: &Catcher, other: &Catcher) -> bool {
+    catcher.error_type.as_ref().map(|(i, _)| i) == other.error_type.as_ref().map(|(i, _)| i) 
 }
 
 #[cfg(test)]

--- a/core/lib/src/router/matcher.rs
+++ b/core/lib/src/router/matcher.rs
@@ -122,14 +122,14 @@ impl Catcher {
     /// // Let's say `request` is `GET /` that 404s. The error matches only `a`:
     /// let request = client.get("/");
     /// # let request = request.inner();
-    /// assert!(a.matches(Status::NotFound, &request));
-    /// assert!(!b.matches(Status::NotFound, &request));
+    /// assert!(a.matches(Status::NotFound, &request, None));
+    /// assert!(!b.matches(Status::NotFound, &request, None));
     ///
     /// // Now `request` is a 404 `GET /bar`. The error matches `a` and `b`:
     /// let request = client.get("/bar");
     /// # let request = request.inner();
-    /// assert!(a.matches(Status::NotFound, &request));
-    /// assert!(b.matches(Status::NotFound, &request));
+    /// assert!(a.matches(Status::NotFound, &request, None));
+    /// assert!(b.matches(Status::NotFound, &request, None));
     ///
     /// // Note that because `b`'s base' has more complete segments that `a's,
     /// // Rocket would route the error to `b`, not `a`, even though both match.

--- a/core/lib/src/router/matcher.rs
+++ b/core/lib/src/router/matcher.rs
@@ -137,18 +137,11 @@ impl Catcher {
     /// let b_count = b.base().segments().filter(|s| !s.is_empty()).count();
     /// assert!(b_count > a_count);
     /// ```
+    // TODO: document error matching
     pub fn matches(&self, status: Status, request: &Request<'_>, error: Option<TypeId>) -> bool {
         self.code.map_or(true, |code| code == status.code)
-            && self.error_matches(error)
+            && error == self.error_type.map(|(ty, _)| ty)
             && self.base().segments().prefix_of(request.uri().path().segments())
-    }
-
-    fn error_matches(&self, error: Option<TypeId>) -> bool {
-        if let Some((ty, _)) = self.error_type {
-            error.map_or(false, |t| t == ty)
-        } else {
-            true
-        }
     }
 }
 

--- a/core/lib/src/router/matcher.rs
+++ b/core/lib/src/router/matcher.rs
@@ -1,6 +1,5 @@
 use transient::TypeId;
 
-use crate::catcher::TypedError;
 use crate::{Route, Request, Catcher};
 use crate::router::Collide;
 use crate::http::Status;
@@ -89,6 +88,7 @@ impl Catcher {
     ///     [`status`](Status::code) _or_ is `default`.
     ///   * The catcher's [base](Catcher::base()) is a prefix of the `request`'s
     ///     [normalized](crate::http::uri::Origin#normalization) URI.
+    ///   * The catcher has the same [type](Catcher::error_type).
     ///
     /// For an error arising from a request to be routed to a particular
     /// catcher, that catcher must both `match` _and_ have higher precedence
@@ -96,15 +96,21 @@ impl Catcher {
     /// necessary but insufficient condition to determine if a catcher will
     /// handle a particular error.
     ///
-    /// TODO: typed: The following has changed
     /// The precedence of a catcher is determined by:
     ///
     ///   1. The number of _complete_ segments in the catcher's `base`.
+    ///   3. The error type.
     ///   2. Whether the catcher is `default` or not.
     ///
     /// Non-default routes, and routes with more complete segments in their
     /// base, have higher precedence.
     ///
+    /// TODO: typed: Exact number has not yet been decided
+    /// During the routing process, [`.source()`] is called up to 5 times on
+    /// the error. This produces a sequence of types, and catchers that match
+    /// types earlier in the sequence are prefered.
+    ///
+    /// [`.source()`]: rocket::catcher::TypedError::source
     /// # Example
     ///
     /// ```rust
@@ -138,7 +144,6 @@ impl Catcher {
     /// let b_count = b.base().segments().filter(|s| !s.is_empty()).count();
     /// assert!(b_count > a_count);
     /// ```
-    // TODO: document error matching
     pub fn matches(&self, status: Status, request: &Request<'_>, error: Option<TypeId>) -> bool {
         self.code.map_or(true, |code| code == status.code)
             && error == self.error_type.map(|(ty, _)| ty)

--- a/core/lib/src/router/matcher.rs
+++ b/core/lib/src/router/matcher.rs
@@ -96,6 +96,7 @@ impl Catcher {
     /// necessary but insufficient condition to determine if a catcher will
     /// handle a particular error.
     ///
+    /// TODO: typed: The following has changed
     /// The precedence of a catcher is determined by:
     ///
     ///   1. The number of _complete_ segments in the catcher's `base`.

--- a/core/lib/src/router/router.rs
+++ b/core/lib/src/router/router.rs
@@ -56,14 +56,18 @@ impl Router {
 
     // For many catchers, using aho-corasick or similar should be much faster.
     // TODO: document difference between catch, and catch_any
-    pub fn catch<'r>(&self, status: Status, req: &'r Request<'r>, error: Option<TypeId>) -> Option<&Catcher> {
+    pub fn catch<'r>(&self, status: Status, req: &'r Request<'r>, error: Option<TypeId>)
+        -> Option<&Catcher>
+    {
         // Note that catchers are presorted by descending base length.
         self.catchers.get(&Some(status.code))
             .and_then(|c| c.iter().find(|c| c.matches(status, req, error)))
     }
 
     // For many catchers, using aho-corasick or similar should be much faster.
-    pub fn catch_any<'r>(&self, status: Status, req: &'r Request<'r>, error: Option<TypeId>) -> Option<&Catcher> {
+    pub fn catch_any<'r>(&self, status: Status, req: &'r Request<'r>, error: Option<TypeId>)
+        -> Option<&Catcher>
+    {
         // Note that catchers are presorted by descending base length.
         self.catchers.get(&None)
             .and_then(|c| c.iter().find(|c| c.matches(status, req, error)))
@@ -556,7 +560,9 @@ mod test {
         router
     }
 
-    fn catcher<'a>(router: &'a Router, status: Status, uri: &str, error_ty: Option<TypeId>) -> Option<&'a Catcher> {
+    fn catcher<'a>(router: &'a Router, status: Status, uri: &str, error_ty: Option<TypeId>)
+        -> Option<&'a Catcher>
+    {
         let client = Client::debug_with(vec![]).expect("client");
         let request = client.get(Origin::parse(uri).unwrap());
         router.catch(status, &request, error_ty)

--- a/core/lib/src/router/router.rs
+++ b/core/lib/src/router/router.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use transient::TypeId;
 
+use crate::catcher::TypedError;
 use crate::request::Request;
 use crate::http::{Method, Status};
 
@@ -54,16 +55,18 @@ impl Router {
     }
 
     // For many catchers, using aho-corasick or similar should be much faster.
-    pub fn catch<'r>(&self, status: Status, req: &'r Request<'r>, error_ty: Option<TypeId>) -> Option<&Catcher> {
+    // TODO: document difference between catch, and catch_any
+    pub fn catch<'r>(&self, status: Status, req: &'r Request<'r>, error: Option<TypeId>) -> Option<&Catcher> {
         // Note that catchers are presorted by descending base length.
         self.catchers.get(&Some(status.code))
-            .and_then(|c| c.iter().find(|c| c.matches(status, req, error_ty)))
+            .and_then(|c| c.iter().find(|c| c.matches(status, req, error)))
     }
 
-    pub fn catch_any<'r>(&self, status: Status, req: &'r Request<'r>, error_ty: Option<TypeId>) -> Option<&Catcher> {
+    // For many catchers, using aho-corasick or similar should be much faster.
+    pub fn catch_any<'r>(&self, status: Status, req: &'r Request<'r>, error: Option<TypeId>) -> Option<&Catcher> {
         // Note that catchers are presorted by descending base length.
         self.catchers.get(&None)
-            .and_then(|c| c.iter().find(|c| c.matches(status, req, error_ty)))
+            .and_then(|c| c.iter().find(|c| c.matches(status, req, error)))
     }
 
     fn collisions<'a, I, T>(&self, items: I) -> impl Iterator<Item = (T, T)> + 'a

--- a/core/lib/src/router/router.rs
+++ b/core/lib/src/router/router.rs
@@ -578,7 +578,6 @@ mod test {
             let router = router_with_catchers(&catchers);
             for (req, expected) in requests.iter().zip(expected.iter()) {
                 let req_status = Status::from_code(req.0).expect("valid status");
-                // TODO: write test cases for typed variant
                 let catcher = catcher(&router, req_status, req.1, req.2).expect("some catcher");
                 assert_eq!(catcher.code, expected.0,
                     "\nmatched {:?}, expected {:?} for req {:?}", catcher, expected, req);

--- a/core/lib/src/sentinel.rs
+++ b/core/lib/src/sentinel.rs
@@ -150,11 +150,12 @@ use crate::{Rocket, Ignite};
 /// use rocket::response::Responder;
 /// # type AnotherSentinel = ();
 ///
-/// #[get("/")]
-/// fn f<'r>() -> Either<impl Responder<'r, 'static>, AnotherSentinel> {
-///     /* ... */
-///     # Either::Left(())
-/// }
+/// // TODO: this no longer compiles, since the `impl Responder` doesn't meet the full reqs
+/// // #[get("/")]
+/// // fn f<'r>() -> Either<impl Responder<'r, 'static>, AnotherSentinel> {
+/// //     /* ... */
+/// //     # Either::Left(())
+/// // }
 /// ```
 ///
 /// **Note:** _Rocket actively discourages using `impl Trait` in route

--- a/core/lib/src/sentinel.rs
+++ b/core/lib/src/sentinel.rs
@@ -144,18 +144,26 @@ use crate::{Rocket, Ignite};
 ///
 /// Occasionally an existential `impl Trait` may find its way into return types:
 ///
+/// **Note:** _This example actually doesn't work right now - `impl Responder` isn't
+/// enough to use as a type argument to `Either`. We might be able to do something
+/// about this - we would have to remove the TypedError impl on Either, and instead
+/// use a specialization trick to handle it at the point we convert it to a dyn box._
+///
 /// ```rust
 /// # use rocket::*;
 /// # use either::Either;
+/// # use std::convert::Infallible;
 /// use rocket::response::Responder;
 /// # type AnotherSentinel = ();
 ///
 /// // TODO: this no longer compiles, since the `impl Responder` doesn't meet the full reqs
-/// // #[get("/")]
-/// // fn f<'r>() -> Either<impl Responder<'r, 'static>, AnotherSentinel> {
-/// //     /* ... */
-/// //     # Either::Left(())
-/// // }
+/// // For a type `T`, `Either` requires: `T: Responder<'r, 'o>` _and_
+/// // `T::Error: CanTransendTo<Inv<'r>>`
+/// #[get("/")]
+/// fn f<'r>() -> Either<impl Responder<'r, 'static, Error = Infallible>, AnotherSentinel> {
+///     /* ... */
+///     # Either::Left(())
+/// }
 /// ```
 ///
 /// **Note:** _Rocket actively discourages using `impl Trait` in route

--- a/core/lib/src/sentinel.rs
+++ b/core/lib/src/sentinel.rs
@@ -156,9 +156,6 @@ use crate::{Rocket, Ignite};
 /// use rocket::response::Responder;
 /// # type AnotherSentinel = ();
 ///
-/// // TODO: this no longer compiles, since the `impl Responder` doesn't meet the full reqs
-/// // For a type `T`, `Either` requires: `T: Responder<'r, 'o>` _and_
-/// // `T::Error: CanTransendTo<Inv<'r>>`
 /// #[get("/")]
 /// fn f<'r>() -> Either<impl Responder<'r, 'static, Error = Infallible>, AnotherSentinel> {
 ///     /* ... */

--- a/core/lib/src/serde/json.rs
+++ b/core/lib/src/serde/json.rs
@@ -27,6 +27,7 @@
 use std::{io, fmt, error};
 use std::ops::{Deref, DerefMut};
 
+use crate::catcher::TypedError;
 use crate::request::{Request, local_cache};
 use crate::data::{Limits, Data, FromData, Outcome};
 use crate::response::{self, Responder, content};
@@ -139,6 +140,8 @@ pub enum Error<'a> {
     /// error from `serde`.
     Parse(&'a str, serde_json::error::Error),
 }
+
+impl<'a> TypedError<'a> for Error<'a> {  }
 
 unsafe impl<'a> Transient for Error<'a> {
     type Static = Error<'static>;

--- a/core/lib/src/serde/json.rs
+++ b/core/lib/src/serde/json.rs
@@ -35,6 +35,7 @@ use crate::http::uri::fmt::{UriDisplay, FromUriParam, Query, Formatter as UriFor
 use crate::http::Status;
 
 use serde::{Serialize, Deserialize};
+use transient::Transient;
 
 #[doc(hidden)]
 pub use serde_json;
@@ -137,6 +138,11 @@ pub enum Error<'a> {
     /// received from the user, while the `Error` in `.1` is the deserialization
     /// error from `serde`.
     Parse(&'a str, serde_json::error::Error),
+}
+
+unsafe impl<'a> Transient for Error<'a> {
+    type Static = Error<'static>;
+    type Transience = transient::Co<'a>;
 }
 
 impl<'a> fmt::Display for Error<'a> {

--- a/core/lib/src/serde/json.rs
+++ b/core/lib/src/serde/json.rs
@@ -222,14 +222,17 @@ impl<'r, T: Deserialize<'r>> FromData<'r> for Json<T> {
 /// JSON and a fixed-size body with the serialized value. If serialization
 /// fails, an `Err` of `Status::InternalServerError` is returned.
 impl<'r, T: Serialize> Responder<'r, 'static> for Json<T> {
-    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'static> {
-        let string = serde_json::to_string(&self.0)
-            .map_err(|e| {
+    type Error = serde_json::Error;
+    fn respond_to(self, req: &'r Request<'_>) -> response::Outcome<'static, Self::Error> {
+        let string = match serde_json::to_string(&self.0) {
+            Ok(v) => v,
+            Err(e) => {
                 error!("JSON serialize failure: {}", e);
-                Status::InternalServerError
-            })?;
+                return response::Outcome::Error(e);
+            }
+        };
 
-        content::RawJson(string).respond_to(req)
+        content::RawJson(string).respond_to(req).map_error(|e| match e {})
     }
 }
 
@@ -304,7 +307,8 @@ impl<'v, T: Deserialize<'v> + Send> form::FromFormField<'v> for Json<T> {
 /// Serializes the value into JSON. Returns a response with Content-Type JSON
 /// and a fixed-size body with the serialized value.
 impl<'r> Responder<'r, 'static> for Value {
-    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'static> {
+    type Error = std::convert::Infallible;
+    fn respond_to(self, req: &'r Request<'_>) -> response::Outcome<'static, Self::Error> {
         content::RawJson(self.to_string()).respond_to(req)
     }
 }

--- a/core/lib/src/serde/json.rs
+++ b/core/lib/src/serde/json.rs
@@ -204,7 +204,7 @@ impl<'r, T: Deserialize<'r>> Json<T> {
 
 #[crate::async_trait]
 impl<'r, T: Deserialize<'r>> FromData<'r> for Json<T> {
-    type Error = Error<'r>;
+    type Error = (Status, Error<'r>);
 
     async fn from_data(req: &'r Request<'_>, data: Data<'r>) -> Outcome<'r, Self> {
         match Self::from_data(req, data).await {

--- a/core/lib/src/serde/msgpack.rs
+++ b/core/lib/src/serde/msgpack.rs
@@ -164,7 +164,7 @@ impl<'r, T: Deserialize<'r>> MsgPack<T> {
 
 #[crate::async_trait]
 impl<'r, T: Deserialize<'r>> FromData<'r> for MsgPack<T> {
-    type Error = Error;
+    type Error = (Status, Error);
 
     async fn from_data(req: &'r Request<'_>, data: Data<'r>) -> Outcome<'r, Self> {
         match Self::from_data(req, data).await {
@@ -196,11 +196,8 @@ impl<'r, T: Serialize> Responder<'r, 'static> for MsgPack<T> {
                 return response::Outcome::Error(e);
             }
         };
-            // .map_err(|e| {
-            //     Status::InternalServerError
-            // })?;
 
-        content::RawMsgPack(buf).respond_to(req).map_err_type()
+        content::RawMsgPack(buf).respond_to(req).map_error(|e| match e {})
     }
 }
 
@@ -220,6 +217,7 @@ impl<'v, T: Deserialize<'v> + Send> form::FromFormField<'v> for MsgPack<T> {
     }
 }
 
+// TODO: why is the commented out?
 // impl<T: Serialize> fmt::UriDisplay<fmt::Query> for MsgPack<T> {
 //     fn fmt(&self, f: &mut fmt::Formatter<'_, fmt::Query>) -> std::fmt::Result {
 //         let bytes = to_vec(&self.0).map_err(|_| std::fmt::Error)?;

--- a/core/lib/src/serde/msgpack.rs
+++ b/core/lib/src/serde/msgpack.rs
@@ -188,16 +188,16 @@ impl<'r, T: Deserialize<'r>> FromData<'r> for MsgPack<T> {
 /// serialization fails, an `Err` of `Status::InternalServerError` is returned.
 impl<'r, T: Serialize> Responder<'r, 'static> for MsgPack<T> {
     type Error = rmp_serde::encode::Error;
-    fn respond_to(self, req: &'r Request<'_>) -> response::Outcome<'static, Self::Error> {
+    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'static, Self::Error> {
         let buf = match rmp_serde::to_vec(&self.0) {
             Ok(v) => v,
             Err(e) => {
                 error!("MsgPack serialize failure: {}", e);
-                return response::Outcome::Error(e);
+                return Err(e);
             }
         };
 
-        content::RawMsgPack(buf).respond_to(req).map_error(|e| match e {})
+        content::RawMsgPack(buf).respond_to(req).map_err(|e| match e {})
     }
 }
 

--- a/core/lib/src/server.rs
+++ b/core/lib/src/server.rs
@@ -42,7 +42,7 @@ impl Rocket<Orbit> {
         span_debug!("request headers" => request.inner().headers().iter().trace_all_debug());
         let mut response = request.into_response(
             stream,
-            |rocket, request, data| Box::pin(rocket.preprocess(request, data)),
+            |rocket, request, data, error_ptr| Box::pin(rocket.preprocess(request, data, error_ptr)),
             |token, rocket, request, data, error_ptr| Box::pin(async move {
                 if !request.errors.is_empty() {
                     *error_ptr =  Some(Box::new(RequestErrors::new(&request.errors)));

--- a/core/lib/src/server.rs
+++ b/core/lib/src/server.rs
@@ -9,6 +9,7 @@ use hyper_util::server::conn::auto::Builder;
 use futures::{Future, TryFutureExt};
 use tokio::io::{AsyncRead, AsyncWrite};
 
+use crate::catcher::default_error_type;
 use crate::{Ignite, Orbit, Request, Rocket};
 use crate::request::ConnectionMeta;
 use crate::erased::{ErasedRequest, ErasedResponse, ErasedIoHandler};
@@ -45,7 +46,7 @@ impl Rocket<Orbit> {
             |rocket, request, data| Box::pin(rocket.preprocess(request, data)),
             |token, rocket, request, data| Box::pin(async move {
                 if !request.errors.is_empty() {
-                    return rocket.dispatch_error(Status::BadRequest, request).await;
+                    return rocket.dispatch_error(Status::BadRequest, request, default_error_type()).await;
                 }
 
                 rocket.dispatch(token, request, data).await

--- a/core/lib/src/server.rs
+++ b/core/lib/src/server.rs
@@ -9,9 +9,8 @@ use hyper_util::server::conn::auto::Builder;
 use futures::{Future, TryFutureExt};
 use tokio::io::{AsyncRead, AsyncWrite};
 
-use crate::catcher::default_error_type;
 use crate::{Ignite, Orbit, Request, Rocket};
-use crate::request::ConnectionMeta;
+use crate::request::{ConnectionMeta, RequestErrors};
 use crate::erased::{ErasedRequest, ErasedResponse, ErasedIoHandler};
 use crate::listener::{Listener, Connection, BouncedExt, CancellableExt};
 use crate::error::log_server_error;
@@ -49,7 +48,7 @@ impl Rocket<Orbit> {
                     return rocket.dispatch_error(
                         Status::BadRequest,
                         request,
-                        default_error_type()
+                        Some(Box::new(RequestErrors::new(&request.errors)))
                     ).await;
                 }
 

--- a/core/lib/src/server.rs
+++ b/core/lib/src/server.rs
@@ -45,11 +45,11 @@ impl Rocket<Orbit> {
             |rocket, request, data, error_ptr| Box::pin(rocket.preprocess(request, data, error_ptr)),
             |token, rocket, request, data, error_ptr| Box::pin(async move {
                 if !request.errors.is_empty() {
-                    *error_ptr =  Some(Box::new(RequestErrors::new(&request.errors)));
+                    error_ptr.write(Some(Box::new(RequestErrors::new(&request.errors))));
                     return rocket.dispatch_error(
                         Status::BadRequest,
                         request,
-                        error_ptr.as_ref().map(|b| b.as_ref())
+                        error_ptr.get(),
                     ).await;
                 }
 

--- a/core/lib/src/server.rs
+++ b/core/lib/src/server.rs
@@ -46,7 +46,11 @@ impl Rocket<Orbit> {
             |rocket, request, data| Box::pin(rocket.preprocess(request, data)),
             |token, rocket, request, data| Box::pin(async move {
                 if !request.errors.is_empty() {
-                    return rocket.dispatch_error(Status::BadRequest, request, default_error_type()).await;
+                    return rocket.dispatch_error(
+                        Status::BadRequest,
+                        request,
+                        default_error_type()
+                    ).await;
                 }
 
                 rocket.dispatch(token, request, data).await

--- a/core/lib/src/server.rs
+++ b/core/lib/src/server.rs
@@ -42,7 +42,9 @@ impl Rocket<Orbit> {
         span_debug!("request headers" => request.inner().headers().iter().trace_all_debug());
         let mut response = request.into_response(
             stream,
-            |rocket, request, data, error_ptr| Box::pin(rocket.preprocess(request, data, error_ptr)),
+            |rocket, request, data, error_ptr| {
+                Box::pin(rocket.preprocess(request, data, error_ptr))
+            },
             |token, rocket, request, data, error_ptr| Box::pin(async move {
                 if !request.errors.is_empty() {
                     error_ptr.write(Some(Box::new(RequestErrors::new(&request.errors))));

--- a/core/lib/src/state.rs
+++ b/core/lib/src/state.rs
@@ -193,10 +193,10 @@ impl<'r, T: Send + Sync + 'static> From<&'r T> for &'r State<T> {
 
 #[crate::async_trait]
 impl<'r, T: Send + Sync + 'static> FromRequest<'r> for &'r State<T> {
-    type Error = ();
+    type Error = Status;
 
     #[inline(always)]
-    async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, ()> {
+    async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
         match State::get(req.rocket()) {
             Some(state) => Outcome::Success(state),
             None => {
@@ -204,7 +204,7 @@ impl<'r, T: Send + Sync + 'static> FromRequest<'r> for &'r State<T> {
                 "retrieving unmanaged state\n\
                 state must be managed via `rocket.manage()`");
 
-                Outcome::Error((Status::InternalServerError, ()))
+                Outcome::Error(Status::InternalServerError)
             }
         }
     }

--- a/core/lib/src/trace/traceable.rs
+++ b/core/lib/src/trace/traceable.rs
@@ -245,7 +245,7 @@ impl Trace for route::Outcome<'_> {
             status = match self {
                 Self::Success(r) => r.status().code,
                 Self::Error((s, _)) => s.code,
-                Self::Forward((_, s)) => s.code,
+                Self::Forward((_, s, _)) => s.code,
             },
         )
     }

--- a/core/lib/src/trace/traceable.rs
+++ b/core/lib/src/trace/traceable.rs
@@ -244,8 +244,8 @@ impl Trace for route::Outcome<'_> {
             },
             status = match self {
                 Self::Success(r) => r.status().code,
-                Self::Error((s, _)) => s.code,
-                Self::Forward((_, s, _)) => s.code,
+                Self::Error(e) => e.status().code,
+                Self::Forward((_, e)) => e.status().code,
             },
         )
     }

--- a/core/lib/src/trace/traceable.rs
+++ b/core/lib/src/trace/traceable.rs
@@ -244,7 +244,7 @@ impl Trace for route::Outcome<'_> {
             },
             status = match self {
                 Self::Success(r) => r.status().code,
-                Self::Error(s) => s.code,
+                Self::Error((s, _)) => s.code,
                 Self::Forward((_, s)) => s.code,
             },
         )

--- a/core/lib/tests/catcher-cookies-1213.rs
+++ b/core/lib/tests/catcher-cookies-1213.rs
@@ -1,11 +1,10 @@
 #[macro_use] extern crate rocket;
 
-use rocket::request::Request;
 use rocket::http::CookieJar;
 
 #[catch(404)]
-fn not_found(request: &Request<'_>) -> &'static str {
-    request.cookies().add(("not_found", "404"));
+fn not_found(jar: &CookieJar<'_>) -> &'static str {
+    jar.add(("not_found", "404"));
     "404 - Not Found"
 }
 

--- a/core/lib/tests/panic-handling.rs
+++ b/core/lib/tests/panic-handling.rs
@@ -1,6 +1,6 @@
 #[macro_use] extern crate rocket;
 
-use rocket::catcher::ErasedErrorRef;
+use rocket::catcher::ErasedError;
 use rocket::{Request, Rocket, Route, Catcher, Build, route, catcher};
 use rocket::data::Data;
 use rocket::http::{Method, Status};
@@ -74,7 +74,9 @@ fn catches_early_route_panic() {
 
 #[test]
 fn catches_early_catcher_panic() {
-    fn pre_future_catcher<'r>(_: Status, _: &'r Request<'_>, _: &ErasedErrorRef<'r>) -> catcher::BoxFuture<'r> {
+    fn pre_future_catcher<'r>(_: Status, _: &'r Request<'_>, _: ErasedError<'r>)
+        -> catcher::BoxFuture<'r>
+    {
         panic!("a panicking pre-future catcher")
     }
 

--- a/core/lib/tests/panic-handling.rs
+++ b/core/lib/tests/panic-handling.rs
@@ -1,5 +1,6 @@
 #[macro_use] extern crate rocket;
 
+use rocket::catcher::ErasedErrorRef;
 use rocket::{Request, Rocket, Route, Catcher, Build, route, catcher};
 use rocket::data::Data;
 use rocket::http::{Method, Status};
@@ -73,7 +74,7 @@ fn catches_early_route_panic() {
 
 #[test]
 fn catches_early_catcher_panic() {
-    fn pre_future_catcher<'r>(_: Status, _: &'r Request<'_>) -> catcher::BoxFuture<'r> {
+    fn pre_future_catcher<'r>(_: Status, _: &'r Request<'_>, _: &ErasedErrorRef<'r>) -> catcher::BoxFuture<'r> {
         panic!("a panicking pre-future catcher")
     }
 

--- a/core/lib/tests/panic-handling.rs
+++ b/core/lib/tests/panic-handling.rs
@@ -1,6 +1,6 @@
 #[macro_use] extern crate rocket;
 
-use rocket::catcher::ErasedError;
+use rocket::catcher::TypedError;
 use rocket::{Request, Rocket, Route, Catcher, Build, route, catcher};
 use rocket::data::Data;
 use rocket::http::{Method, Status};
@@ -74,7 +74,7 @@ fn catches_early_route_panic() {
 
 #[test]
 fn catches_early_catcher_panic() {
-    fn pre_future_catcher<'r>(_: Status, _: &'r Request<'_>, _: ErasedError<'r>)
+    fn pre_future_catcher<'r>(_: Status, _: &'r Request<'_>, _: Option<&'r dyn TypedError<'r>>)
         -> catcher::BoxFuture<'r>
     {
         panic!("a panicking pre-future catcher")

--- a/core/lib/tests/responder_lifetime-issue-345.rs
+++ b/core/lib/tests/responder_lifetime-issue-345.rs
@@ -13,7 +13,7 @@ pub struct CustomResponder<'r, R> {
 }
 
 impl<'r, 'o: 'r, R: Responder<'r, 'o>> Responder<'r, 'o> for CustomResponder<'r, R> {
-    type Error = <R as Responder>::Error;
+    type Error = <R as Responder<'r, 'o>>::Error;
     fn respond_to(self, req: &'r Request<'_>) -> Outcome<'o, Self::Error> {
         self.responder.respond_to(req)
     }

--- a/core/lib/tests/responder_lifetime-issue-345.rs
+++ b/core/lib/tests/responder_lifetime-issue-345.rs
@@ -3,7 +3,7 @@
 #[macro_use] extern crate rocket;
 
 use rocket::{Request, State};
-use rocket::response::{Responder, Result};
+use rocket::response::{Responder, Outcome};
 
 struct SomeState;
 
@@ -13,7 +13,8 @@ pub struct CustomResponder<'r, R> {
 }
 
 impl<'r, 'o: 'r, R: Responder<'r, 'o>> Responder<'r, 'o> for CustomResponder<'r, R> {
-    fn respond_to(self, req: &'r Request<'_>) -> Result<'o> {
+    type Error = <R as Responder>::Error;
+    fn respond_to(self, req: &'r Request<'_>) -> Outcome<'o, Self::Error> {
         self.responder.respond_to(req)
     }
 }

--- a/core/lib/tests/responder_lifetime-issue-345.rs
+++ b/core/lib/tests/responder_lifetime-issue-345.rs
@@ -3,7 +3,7 @@
 #[macro_use] extern crate rocket;
 
 use rocket::{Request, State};
-use rocket::response::{Responder, Outcome};
+use rocket::response::{Responder, Result};
 
 struct SomeState;
 
@@ -14,7 +14,7 @@ pub struct CustomResponder<'r, R> {
 
 impl<'r, 'o: 'r, R: Responder<'r, 'o>> Responder<'r, 'o> for CustomResponder<'r, R> {
     type Error = <R as Responder<'r, 'o>>::Error;
-    fn respond_to(self, req: &'r Request<'_>) -> Outcome<'o, Self::Error> {
+    fn respond_to(self, req: &'r Request<'_>) -> Result<'o, Self::Error> {
         self.responder.respond_to(req)
     }
 }

--- a/core/lib/tests/sentinel.rs
+++ b/core/lib/tests/sentinel.rs
@@ -151,7 +151,7 @@ fn inner_sentinels_detected() {
 
     #[derive(Responder)]
     struct MyThing<T>(T);
-    
+
     #[derive(Debug, Transient)]
     struct ResponderSentinel;
     impl TypedError<'_> for ResponderSentinel {}

--- a/core/lib/tests/sentinel.rs
+++ b/core/lib/tests/sentinel.rs
@@ -158,7 +158,7 @@ fn inner_sentinels_detected() {
 
     impl<'r, 'o: 'r> response::Responder<'r, 'o> for ResponderSentinel {
         type Error = std::convert::Infallible;
-        fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'o, Self::Error> {
+        fn respond_to(self, _: &'r Request<'_>) -> response::Result<'o, Self::Error> {
             unimplemented!()
         }
     }

--- a/docs/guide/01-upgrading.md
+++ b/docs/guide/01-upgrading.md
@@ -12,6 +12,9 @@ Whenever a guard fails with a type, such as a `FromParam`, `FromRequest`, etc
 implementation, the error type is boxed up, and can be retrieved by catchers.
 This well-requested feature makes providing useful error types much easier.
 
+The simplest way to start is by returning a `Result` from a route. At long as
+it implements `TypedError`, the `Err` variant can be caught by a typed catcher.
+
 The following example mounts a single route, and a catcher that will catch any
 invalid integer parameters. The catcher then formats the error into a JSON
 object and returns it.

--- a/docs/guide/01-upgrading.md
+++ b/docs/guide/01-upgrading.md
@@ -6,6 +6,61 @@ summary = "a migration guide from Rocket v0.5 to v0.6"
 
 This a placeholder for an eventual migration guide from v0.5 to v0.6.
 
+## Typed Errors and Catchers
+
+Whenever a guard fails with a type, such as a `FromParam`, `FromRequest`, etc
+implementation, the error type is boxed up, and can be retrieved by catchers.
+This well-requested feature makes providing useful error types much easier.
+
+The following example mounts a single route, and a catcher that will catch any
+invalid integer parameters. The catcher then formats the error into a JSON
+object and returns it.
+
+TODO: add tests, and make this run?
+```rust,no_run
+# #[macro_use] extern crate rocket;
+use std::num::ParseIntError;
+
+use rocket::Responder;
+use rocket::serde::{Serialize, json::Json};
+use rocket::request::FromParamError;
+
+#[derive(Responder)]
+#[response(status = 422)]
+struct ParameterError<T>(T);
+
+#[derive(Serialize)]
+#[serde(crate = "rocket::serde")]
+struct ErrorInfo<'a> {
+    invalid_value: &'a str,
+    description: String,
+}
+
+#[catch(422, error = "<int_error>")]
+fn catch_invalid_int<'a>(
+    // `&ParseIntError` would also work here, but `&FromParamError<ParseIntError>`
+    // also gives us access to `raw`, the specific segment that failed to parse.
+    int_error: &FromParamError<'a, ParseIntError>
+) -> ParameterError<Json<ErrorInfo<'a>>> {
+    ParameterError(Json(ErrorInfo {
+        invalid_value: int_error.raw,
+        description: format!("{}", int_error.error),
+    }))
+}
+
+/// A simple route with a single parameter. If you pass this a valid `u8`,
+/// it will return a string. However, if you pass it something invalid as a `u8`,
+/// such as `-1`, `1234`, or `apple`, the catcher above will be respond with
+/// details on the error.
+#[get("/<number>")]
+fn number(number: u8) -> String {
+    format!("You selected {}", number)
+}
+```
+
+To see a full demonstration of this feature, check out the error-handling
+(TODO: link) example.
+
 ## Getting Help
 
 If you run into any issues upgrading, we encourage you to ask questions via

--- a/docs/guide/05-requests.md
+++ b/docs/guide/05-requests.md
@@ -540,7 +540,9 @@ use rocket::http::Status;
 
 #[derive(Debug, TypedError)]
 enum LoginError {
+    #[error(status = 401)]
     NotLoggedIn,
+    #[error(status = 401)]
     NotAdmin,
 }
 
@@ -552,9 +554,9 @@ impl<'r> FromRequest<'r> for AdminUser {
         if is_logged_in_as_admin(r) {
             Outcome::Success(Self {})
         } else if is_logged_in(r) {
-            Outcome::Error((Status::Unauthorized, LoginError::NotAdmin))
+            Outcome::Error(LoginError::NotAdmin)
         } else {
-            Outcome::Error((Status::Unauthorized, LoginError::NotLoggedIn))
+            Outcome::Error(LoginError::NotLoggedIn)
         }
     }
 }

--- a/docs/guide/05-requests.md
+++ b/docs/guide/05-requests.md
@@ -1981,14 +1981,14 @@ Application processing is fallible. Errors arise from the following sources:
   * A routing failure.
 
 If any of these occur, Rocket returns an error to the client. To generate the
-error, Rocket invokes the _catcher_ corresponding to the error's status code and
-scope. Catchers are similar to routes except in that:
+error, Rocket invokes the _catcher_ corresponding to the error's status code,
+scope, and type. Catchers are similar to routes except in that:
 
   1. Catchers are only invoked on error conditions.
   2. Catchers are declared with the `catch` attribute.
   3. Catchers are _registered_ with [`register()`] instead of [`mount()`].
   4. Any modifications to cookies are cleared before a catcher is invoked.
-  5. Error catchers cannot invoke guards.
+  // 5. Error catchers cannot invoke guards.
   6. Error catchers should not fail to produce a response.
   7. Catchers are scoped to a path prefix.
 
@@ -2000,26 +2000,20 @@ instance, to declare a catcher for `404 Not Found` errors, you'd write:
 # #[macro_use] extern crate rocket;
 # fn main() {}
 
-use rocket::Request;
-
 #[catch(404)]
-fn not_found(req: &Request) { /* .. */ }
+fn not_found() { /* .. */ }
 ```
 
-Catchers may take zero, one, or two arguments. If the catcher takes one
-argument, it must be of type [`&Request`]. It it takes two, they must be of type
-[`Status`] and [`&Request`], in that order. As with routes, the return type must
-implement `Responder`. A concrete implementation may look like:
+TODO: See the catcher documentation
 
 ```rust
 # #[macro_use] extern crate rocket;
 # fn main() {}
-
-# use rocket::Request;
+# use rocket::http::uri::Origin;
 
 #[catch(404)]
-fn not_found(req: &Request) -> String {
-    format!("Sorry, '{}' is not a valid path.", req.uri())
+fn not_found(uri: &Origin) -> String {
+    format!("Sorry, '{}' is not a valid path.", uri)
 }
 ```
 
@@ -2032,8 +2026,7 @@ looks like:
 ```rust
 # #[macro_use] extern crate rocket;
 
-# use rocket::Request;
-# #[catch(404)] fn not_found(req: &Request) { /* .. */ }
+# #[catch(404)] fn not_found() { /* .. */ }
 
 fn main() {
     rocket::build().register("/", catchers![not_found]);
@@ -2106,8 +2099,8 @@ similarly be registered with [`register()`]:
 use rocket::Request;
 use rocket::http::Status;
 
-#[catch(default)]
-fn default_catcher(status: Status, request: &Request) { /* .. */ }
+#[catch(default, status = "<status>")]
+fn default_catcher(status: Status) { /* .. */ }
 
 #[launch]
 fn rocket() -> _ {

--- a/docs/guide/05-requests.md
+++ b/docs/guide/05-requests.md
@@ -519,22 +519,57 @@ As an example, for the `User` guard above, instead of allowing the guard to
 forward in `admin_panel_user`, we might want to detect it and handle it
 dynamically:
 
+TODO: typed: This would actually make much more sense via a typed catcher
+
 ```rust
 # #[macro_use] extern crate rocket;
 # fn main() {}
 
+use rocket::response::Redirect;
+use rocket::request::{self, Request, FromRequest, Outcome};
+use rocket::either::Either;
+use rocket::http::Status;
+
 # type Template = ();
-# type AdminUser = rocket::http::Method;
-# type User = rocket::http::Method;
+// # type AdminUser = rocket::http::Method;
+// # type User = rocket::http::Method;
 # #[get("/login")]
 # fn login() -> Template { /* .. */ }
+# fn is_logged_in_as_admin(r: &Request<'_>) -> bool { true }
+# fn is_logged_in(r: &Request<'_>) -> bool { true }
 
-use rocket::response::Redirect;
+#[derive(Debug, TypedError)]
+enum LoginError {
+    NotLoggedIn,
+    NotAdmin,
+}
 
-#[get("/admin", rank = 2)]
-fn admin_panel_user(user: Option<User>) -> Result<&'static str, Redirect> {
-    let user = user.ok_or_else(|| Redirect::to(uri!(login)))?;
-    Ok("Sorry, you must be an administrator to access this page.")
+struct AdminUser {}
+#[async_trait]
+impl<'r> FromRequest<'r> for AdminUser {
+    type Error = LoginError;
+    async fn from_request(r: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        if is_logged_in_as_admin(r) {
+            Outcome::Success(Self {})
+        } else if is_logged_in(r) {
+            Outcome::Error((Status::Unauthorized, LoginError::NotAdmin))
+        } else {
+            Outcome::Error((Status::Unauthorized, LoginError::NotLoggedIn))
+        }
+    }
+}
+
+#[get("/admin")]
+fn admin_panel(user: AdminUser) -> &'static str {
+    "Welcome to the admin panel"
+}
+
+#[catch(401, error = "<e>")]
+fn catch_login_error(e: &LoginError) -> Either<&'static str, Redirect> {
+    match e {
+        LoginError::NotLoggedIn => Either::Right(Redirect::to(uri!(login))),
+        LoginError::NotAdmin => Either::Left("Admin permissions are required to view this page."),
+    }
 }
 ```
 

--- a/docs/guide/05-requests.md
+++ b/docs/guide/05-requests.md
@@ -2051,7 +2051,7 @@ on implementing [`Transient`] for custom error types.
 
 * The form::Errors type does not (yet) implement Transient
 
-The function arguement must be a reference to the error type expected. See the 
+The function arguement must be a reference to the error type expected. See the
 [error handling example](@git/master/examples/error-handling)
 for a full application, including the route that generates the error.
 

--- a/docs/guide/05-requests.md
+++ b/docs/guide/05-requests.md
@@ -2136,7 +2136,7 @@ similarly be registered with [`register()`]:
 use rocket::Request;
 use rocket::http::Status;
 
-#[catch(default, status = "<status>")]
+#[catch(default)]
 fn default_catcher(status: Status) { /* .. */ }
 
 #[launch]

--- a/docs/guide/06-responses.md
+++ b/docs/guide/06-responses.md
@@ -107,6 +107,42 @@ fn json() -> RawTeapotJson {
 
 ### Errors
 
+TODO: This is probably where we should discuss typed errors
+
+Responders may fail instead of generating a response by returning an `Err`. This
+error can then be caught by a typed catcher. Typed errors can also be generated
+by any other step which can reject a request.
+
+Catchers are used to catch errors, and generate an error response. A simple catcher
+for serving a 404 page might look something like this:
+
+```rust
+# #[macro_use] extern crate rocket;
+# fn main() {}
+# use rocket::http::uri::Origin;
+#[catch(404)]
+fn not_found(uri: &Origin<'_>) -> String {
+    format!("{} does not exist.", uri)
+}
+```
+
+A typed catcher is very similar, but specifies an error parameter. This must be
+a reference to the error type. A catcher to respond when an invalid integer in
+a parameter was specified might look something like this:
+
+```rust
+# #[macro_use] extern crate rocket;
+# fn main() {}
+# use rocket::request::FromParamError;
+# use std::num::ParseIntError;
+#[catch(422, error = "<e>")]
+fn invalid_int(e: &FromParamError<'_, ParseIntError>) -> String {
+    format!("{} is not a valid int. {}", e.raw, e.error)
+}
+```
+
+TODO: the following is old
+
 Responders may fail instead of generating a response by returning an `Err` with
 a status code. When this happens, Rocket forwards the request to the [error
 catcher](../requests/#error-catchers) for that status code.

--- a/docs/guide/06-responses.md
+++ b/docs/guide/06-responses.md
@@ -263,9 +263,11 @@ use rocket::response::{self, Response, Responder};
 use rocket::http::ContentType;
 
 # struct String(std::string::String);
+// TODO: this needs a full update
 #[rocket::async_trait]
 impl<'r> Responder<'r, 'static> for String {
-    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'static> {
+    type Error = std::convert::Infallible;
+    fn respond_to(self, _: &'r Request<'_>) -> response::Outcome<'static, Self::Error> {
         Response::build()
             .header(ContentType::Plain)
             # /*

--- a/docs/guide/14-faq.md
+++ b/docs/guide/14-faq.md
@@ -418,10 +418,13 @@ the example below:
 use rocket::request::Request;
 use rocket::response::{self, Response, Responder};
 use rocket::serde::json::Json;
+use rocket::outcome::try_outcome;
 
+// TODO: this needs a full update
 impl<'r> Responder<'r, 'static> for Person {
-    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'static> {
-        Response::build_from(Json(&self).respond_to(req)?)
+    type Error = <Json<Self> as Responder<'r, 'static>>::Error;
+    fn respond_to(self, req: &'r Request<'_>) -> response::Outcome<'static, Self::Error> {
+        Response::build_from(try_outcome!(Json(&self).respond_to(req)))
             .raw_header("X-Person-Name", self.name)
             .raw_header("X-Person-Age", self.age.to_string())
             .ok()

--- a/examples/cookies/src/session.rs
+++ b/examples/cookies/src/session.rs
@@ -1,4 +1,5 @@
 use rocket::outcome::IntoOutcome;
+use rocket::either::Either;
 use rocket::request::{self, FlashMessage, FromRequest, Request};
 use rocket::response::{Redirect, Flash};
 use rocket::http::{CookieJar, Status};
@@ -58,12 +59,12 @@ fn login_page(flash: Option<FlashMessage<'_>>) -> Template {
 }
 
 #[post("/login", data = "<login>")]
-fn post_login(jar: &CookieJar<'_>, login: Form<Login<'_>>) -> Result<Redirect, Flash<Redirect>> {
+fn post_login(jar: &CookieJar<'_>, login: Form<Login<'_>>) -> Either<Redirect, Flash<Redirect>> {
     if login.username == "Sergio" && login.password == "password" {
         jar.add_private(("user_id", "1"));
-        Ok(Redirect::to(uri!(index)))
+        Either::Left(Redirect::to(uri!(index)))
     } else {
-        Err(Flash::error(Redirect::to(uri!(login_page)), "Invalid username/password."))
+        Either::Right(Flash::error(Redirect::to(uri!(login_page)), "Invalid username/password."))
     }
 }
 

--- a/examples/error-handling/Cargo.toml
+++ b/examples/error-handling/Cargo.toml
@@ -7,3 +7,4 @@ publish = false
 
 [dependencies]
 rocket = { path = "../../core/lib" }
+transient = { path = "/home/matthew/transient" }

--- a/examples/error-handling/Cargo.toml
+++ b/examples/error-handling/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-rocket = { path = "../../core/lib" }
+rocket = { path = "../../core/lib", features = ["json"] }
 transient = { path = "/code/matthew/transient" }

--- a/examples/error-handling/Cargo.toml
+++ b/examples/error-handling/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 
 [dependencies]
 rocket = { path = "../../core/lib" }
-transient = { path = "/home/matthew/transient" }
+transient = { path = "/code/matthew/transient" }

--- a/examples/error-handling/src/main.rs
+++ b/examples/error-handling/src/main.rs
@@ -4,7 +4,7 @@
 
 use rocket::{Rocket, Request, Build};
 use rocket::response::{content, status};
-use rocket::http::{Status, uri::error::PathError};
+use rocket::http::Status;
 
 // Custom impl so I can implement Static (or Transient) ---
 // We should upstream implementations for most common error types
@@ -13,6 +13,7 @@ use rocket::catcher::{Static};
 use std::num::ParseIntError;
 
 #[derive(Debug)]
+#[allow(unused)]
 struct IntErr(ParseIntError);
 impl Static for IntErr {}
 
@@ -45,7 +46,7 @@ fn general_not_found() -> content::RawHtml<&'static str> {
 }
 
 #[catch(404)]
-fn hello_not_found(s: Status, req: &Request<'_>) -> content::RawHtml<String> {
+fn hello_not_found(req: &Request<'_>) -> content::RawHtml<String> {
     content::RawHtml(format!("\
         <p>Sorry, but '{}' is not a valid path!</p>\
         <p>Try visiting /hello/&lt;name&gt;/&lt;age&gt; instead.</p>",
@@ -57,7 +58,7 @@ fn hello_not_found(s: Status, req: &Request<'_>) -> content::RawHtml<String> {
 // be present. I'm thinking about adding a param to the macro to indicate which (and whether)
 // param is a downcast error.
 #[catch(422)]
-fn param_error(e: &IntErr, s: Status, req: &Request<'_>) -> content::RawHtml<String> {
+fn param_error(e: &IntErr, _s: Status, req: &Request<'_>) -> content::RawHtml<String> {
     content::RawHtml(format!("\
         <p>Sorry, but '{}' is not a valid path!</p>\
         <p>Try visiting /hello/&lt;name&gt;/&lt;age&gt; instead.</p>\

--- a/examples/error-handling/src/main.rs
+++ b/examples/error-handling/src/main.rs
@@ -51,13 +51,10 @@ fn hello_not_found(uri: &Origin<'_>) -> content::RawHtml<String> {
         uri))
 }
 
-// Demonstrates a downcast error from `hello`
-// NOTE: right now, the error must be the first parameter, and all three params must
-// be present. I'm thinking about adding a param to the macro to indicate which (and whether)
-// param is a downcast error.
-
-// `error` and `status` type. All other params must be `FromOrigin`?
-#[catch(422, error = "<e>" /*, status = "<_s>"*/)]
+// `error` is typed error. All other parameters must implement `FromError`.
+// Any type that implements `FromRequest` automatically implements `FromError`,
+// as well as `Status`, `&Request` and `&dyn TypedError<'_>`
+#[catch(422, error = "<e>")]
 fn param_error(e: &ParseIntError, uri: &Origin<'_>) -> content::RawHtml<String> {
     content::RawHtml(format!("\
         <p>Sorry, but '{}' is not a valid path!</p>\

--- a/examples/error-handling/src/main.rs
+++ b/examples/error-handling/src/main.rs
@@ -57,7 +57,9 @@ fn hello_not_found(req: &Request<'_>) -> content::RawHtml<String> {
 // NOTE: right now, the error must be the first parameter, and all three params must
 // be present. I'm thinking about adding a param to the macro to indicate which (and whether)
 // param is a downcast error.
-#[catch(422)]
+
+// `error` and `status` type. All other params must be `FromRequest`?
+#[catch(422, error = "<e>" /*, status = "<_s>"*/)]
 fn param_error(e: &IntErr, _s: Status, req: &Request<'_>) -> content::RawHtml<String> {
     content::RawHtml(format!("\
         <p>Sorry, but '{}' is not a valid path!</p>\

--- a/examples/error-handling/src/main.rs
+++ b/examples/error-handling/src/main.rs
@@ -5,31 +5,11 @@
 use rocket::{Rocket, Build};
 use rocket::response::{content, status};
 use rocket::http::{Status, uri::Origin};
-
-// Custom impl so I can implement Static (or Transient) ---
-// We should upstream implementations for most common error types
-// in transient itself
-use rocket::catcher::{Static};
 use std::num::ParseIntError;
 
-#[derive(Debug)]
-#[allow(unused)]
-struct IntErr(ParseIntError);
-impl Static for IntErr {}
-
-struct I8(i8);
-use rocket::request::FromParam;
-impl FromParam<'_> for I8 {
-    type Error = IntErr;
-    fn from_param(param: &str) -> Result<Self, Self::Error> {
-        param.parse::<i8>().map(Self).map_err(IntErr)
-    }
-}
-// ------------------------------
-
 #[get("/hello/<name>/<age>")]
-fn hello(name: &str, age: I8) -> String {
-    format!("Hello, {} year old named {}!", age.0, name)
+fn hello(name: &str, age: i8) -> String {
+    format!("Hello, {} year old named {}!", age, name)
 }
 
 #[get("/<code>")]
@@ -60,7 +40,7 @@ fn hello_not_found(uri: &Origin<'_>) -> content::RawHtml<String> {
 
 // `error` and `status` type. All other params must be `FromOrigin`?
 #[catch(422, error = "<e>" /*, status = "<_s>"*/)]
-fn param_error(e: &IntErr, uri: &Origin<'_>) -> content::RawHtml<String> {
+fn param_error(e: &ParseIntError, uri: &Origin<'_>) -> content::RawHtml<String> {
     content::RawHtml(format!("\
         <p>Sorry, but '{}' is not a valid path!</p>\
         <p>Try visiting /hello/&lt;name&gt;/&lt;age&gt; instead.</p>\

--- a/examples/error-handling/src/tests.rs
+++ b/examples/error-handling/src/tests.rs
@@ -1,6 +1,5 @@
 use rocket::local::blocking::Client;
 use rocket::http::Status;
-use super::{I8, IntErr};
 
 #[test]
 fn test_hello() {
@@ -11,7 +10,7 @@ fn test_hello() {
     let response = client.get(uri).dispatch();
 
     assert_eq!(response.status(), Status::Ok);
-    assert_eq!(response.into_string().unwrap(), super::hello(name, I8(age)));
+    assert_eq!(response.into_string().unwrap(), super::hello(name, age));
 }
 
 #[test]
@@ -50,7 +49,7 @@ fn test_hello_invalid_age() {
     for path in &["Ford/-129", "Trillian/128"] {
         let request = client.get(format!("/hello/{}", path));
         let expected = super::param_error(
-            &IntErr(path.split_once("/").unwrap().1.parse::<i8>().unwrap_err()),
+            &path.split_once("/").unwrap().1.parse::<i8>().unwrap_err(),
             request.uri()
         );
         let response = request.dispatch();

--- a/examples/error-handling/src/tests.rs
+++ b/examples/error-handling/src/tests.rs
@@ -25,19 +25,19 @@ fn forced_error() {
     assert_eq!(response.into_string().unwrap(), expected.0);
 
     let request = client.get("/405");
-    let expected = super::default_catcher(Status::MethodNotAllowed, request.inner());
+    let expected = super::default_catcher(Status::MethodNotAllowed, request.uri());
     let response = request.dispatch();
     assert_eq!(response.status(), Status::MethodNotAllowed);
     assert_eq!(response.into_string().unwrap(), expected.1);
 
     let request = client.get("/533");
-    let expected = super::default_catcher(Status::new(533), request.inner());
+    let expected = super::default_catcher(Status::new(533), request.uri());
     let response = request.dispatch();
     assert_eq!(response.status(), Status::new(533));
     assert_eq!(response.into_string().unwrap(), expected.1);
 
     let request = client.get("/700");
-    let expected = super::default_catcher(Status::InternalServerError, request.inner());
+    let expected = super::default_catcher(Status::InternalServerError, request.uri());
     let response = request.dispatch();
     assert_eq!(response.status(), Status::InternalServerError);
     assert_eq!(response.into_string().unwrap(), expected.1);
@@ -51,8 +51,7 @@ fn test_hello_invalid_age() {
         let request = client.get(format!("/hello/{}", path));
         let expected = super::param_error(
             &IntErr(path.split_once("/").unwrap().1.parse::<i8>().unwrap_err()),
-            Status::UnprocessableEntity,
-            request.inner()
+            request.uri()
         );
         let response = request.dispatch();
         assert_eq!(response.status(), Status::UnprocessableEntity);
@@ -62,7 +61,7 @@ fn test_hello_invalid_age() {
     {
         let path = &"foo/bar/baz";
         let request = client.get(format!("/hello/{}", path));
-        let expected = super::hello_not_found(request.inner());
+        let expected = super::hello_not_found(request.uri());
         let response = request.dispatch();
         assert_eq!(response.status(), Status::NotFound);
         assert_eq!(response.into_string().unwrap(), expected.0);

--- a/examples/responders/src/main.rs
+++ b/examples/responders/src/main.rs
@@ -122,7 +122,8 @@ fn maybe_redir(name: &str) -> Result<&'static str, Redirect> {
 
 /***************************** `content` Responders ***************************/
 
-use rocket::http::{Accept, uri::Origin};
+use rocket::request::Request;
+use rocket::http::uri::Origin;
 use rocket::response::content;
 
 // NOTE: This example explicitly uses the `RawJson` type from
@@ -148,7 +149,7 @@ fn json() -> content::RawJson<&'static str> {
 #[catch(404)]
 fn not_found(req: &Request<'_>, uri: &Origin) -> content::RawHtml<String> {
     let html = match req.format() {
-        Some(ref mt) if !mt.media_types().any(|m| m.is_xml() || m.is_html()) => {
+        Some(ref mt) if !(mt.is_xml() || mt.is_html()) => {
             format!("<p>'{}' requests are not supported.</p>", mt)
         }
         _ => format!("<p>Sorry, '{}' is an invalid path! Try \

--- a/examples/responders/src/main.rs
+++ b/examples/responders/src/main.rs
@@ -143,9 +143,11 @@ fn json() -> content::RawJson<&'static str> {
     content::RawJson(r#"{ "payload": "I'm here" }"#)
 }
 
+// TODO: Should we allow this?
+// Unlike in routes, you actually can use `&Request` in catchers.
 #[catch(404)]
-fn not_found(format: Option<&Accept>, uri: &Origin) -> content::RawHtml<String> {
-    let html = match format {
+fn not_found(req: &Request<'_>, uri: &Origin) -> content::RawHtml<String> {
+    let html = match req.format() {
         Some(ref mt) if !mt.media_types().any(|m| m.is_xml() || m.is_html()) => {
             format!("<p>'{}' requests are not supported.</p>", mt)
         }

--- a/examples/responders/src/main.rs
+++ b/examples/responders/src/main.rs
@@ -122,7 +122,7 @@ fn maybe_redir(name: &str) -> Result<&'static str, Redirect> {
 
 /***************************** `content` Responders ***************************/
 
-use rocket::Request;
+use rocket::http::{Accept, uri::Origin};
 use rocket::response::content;
 
 // NOTE: This example explicitly uses the `RawJson` type from
@@ -144,14 +144,14 @@ fn json() -> content::RawJson<&'static str> {
 }
 
 #[catch(404)]
-fn not_found(request: &Request<'_>) -> content::RawHtml<String> {
-    let html = match request.format() {
-        Some(ref mt) if !(mt.is_xml() || mt.is_html()) => {
+fn not_found(format: Option<&Accept>, uri: &Origin) -> content::RawHtml<String> {
+    let html = match format {
+        Some(ref mt) if !mt.media_types().any(|m| m.is_xml() || m.is_html()) => {
             format!("<p>'{}' requests are not supported.</p>", mt)
         }
         _ => format!("<p>Sorry, '{}' is an invalid path! Try \
                  /hello/&lt;name&gt;/&lt;age&gt; instead.</p>",
-                 request.uri())
+                 uri)
     };
 
     content::RawHtml(html)

--- a/examples/serialization/src/uuid.rs
+++ b/examples/serialization/src/uuid.rs
@@ -7,8 +7,6 @@ use rocket::serde::uuid::Uuid;
 // real application this would be a database.
 struct People(HashMap<Uuid, &'static str>);
 
-// TODO: this is actually the same as previous, since Result<T, E> didn't
-// set or override the status.
 #[get("/people/<id>")]
 fn people(id: Uuid, people: &State<People>) -> String {
     if let Some(person) = people.0.get(&id) {

--- a/examples/serialization/src/uuid.rs
+++ b/examples/serialization/src/uuid.rs
@@ -7,11 +7,15 @@ use rocket::serde::uuid::Uuid;
 // real application this would be a database.
 struct People(HashMap<Uuid, &'static str>);
 
+// TODO: this is actually the same as previous, since Result<T, E> didn't
+// set or override the status.
 #[get("/people/<id>")]
-fn people(id: Uuid, people: &State<People>) -> Result<String, String> {
-    people.0.get(&id)
-        .map(|person| format!("We found: {}", person))
-        .ok_or_else(|| format!("Missing person for UUID: {}", id))
+fn people(id: Uuid, people: &State<People>) -> String {
+    if let Some(person) = people.0.get(&id) {
+        format!("We found: {}", person)
+    } else {
+        format!("Missing person for UUID: {}", id)
+    }
 }
 
 pub fn stage() -> rocket::fairing::AdHoc {

--- a/examples/templating/src/hbs.rs
+++ b/examples/templating/src/hbs.rs
@@ -1,4 +1,4 @@
-use rocket::Request;
+use rocket::http::uri::Origin;
 use rocket::response::Redirect;
 
 use rocket_dyn_templates::{Template, handlebars, context};
@@ -28,9 +28,9 @@ pub fn about() -> Template {
 }
 
 #[catch(404)]
-pub fn not_found(req: &Request<'_>) -> Template {
+pub fn not_found(uri: &Origin<'_>) -> Template {
     Template::render("hbs/error/404", context! {
-        uri: req.uri()
+        uri,
     })
 }
 

--- a/examples/templating/src/tera.rs
+++ b/examples/templating/src/tera.rs
@@ -1,4 +1,4 @@
-use rocket::Request;
+use rocket::http::uri::Origin;
 use rocket::response::Redirect;
 
 use rocket_dyn_templates::{Template, tera::Tera, context};
@@ -25,9 +25,9 @@ pub fn about() -> Template {
 }
 
 #[catch(404)]
-pub fn not_found(req: &Request<'_>) -> Template {
+pub fn not_found(uri: &Origin<'_>) -> Template {
     Template::render("tera/error/404", context! {
-        uri: req.uri()
+        uri,
     })
 }
 

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -70,7 +70,10 @@ async fn toggle(id: i32, conn: DbConn) -> Either<Redirect, Template> {
         Ok(_) => Either::Left(Redirect::to("/")),
         Err(e) => {
             error!("DB toggle({id}) error: {e}");
-            Either::Right(Template::render("index", Context::err(&conn, "Failed to toggle task.").await))
+            Either::Right(Template::render(
+                "index",
+                Context::err(&conn, "Failed to toggle task.").await
+            ))
         }
     }
 }
@@ -81,7 +84,10 @@ async fn delete(id: i32, conn: DbConn) -> Either<Flash<Redirect>, Template> {
         Ok(_) => Either::Left(Flash::success(Redirect::to("/"), "Todo was deleted.")),
         Err(e) => {
             error!("DB deletion({id}) error: {e}");
-            Either::Right(Template::render("index", Context::err(&conn, "Failed to delete task.").await))
+            Either::Right(Template::render(
+                "index",
+                Context::err(&conn, "Failed to delete task.").await
+            ))
         }
     }
 }

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -7,6 +7,7 @@ mod tests;
 mod task;
 
 use rocket::{Rocket, Build};
+use rocket::either::Either;
 use rocket::fairing::AdHoc;
 use rocket::request::FlashMessage;
 use rocket::response::{Flash, Redirect};
@@ -64,23 +65,23 @@ async fn new(todo_form: Form<Todo>, conn: DbConn) -> Flash<Redirect> {
 }
 
 #[put("/<id>")]
-async fn toggle(id: i32, conn: DbConn) -> Result<Redirect, Template> {
+async fn toggle(id: i32, conn: DbConn) -> Either<Redirect, Template> {
     match Task::toggle_with_id(id, &conn).await {
-        Ok(_) => Ok(Redirect::to("/")),
+        Ok(_) => Either::Left(Redirect::to("/")),
         Err(e) => {
             error!("DB toggle({id}) error: {e}");
-            Err(Template::render("index", Context::err(&conn, "Failed to toggle task.").await))
+            Either::Right(Template::render("index", Context::err(&conn, "Failed to toggle task.").await))
         }
     }
 }
 
 #[delete("/<id>")]
-async fn delete(id: i32, conn: DbConn) -> Result<Flash<Redirect>, Template> {
+async fn delete(id: i32, conn: DbConn) -> Either<Flash<Redirect>, Template> {
     match Task::delete_with_id(id, &conn).await {
-        Ok(_) => Ok(Flash::success(Redirect::to("/"), "Todo was deleted.")),
+        Ok(_) => Either::Left(Flash::success(Redirect::to("/"), "Todo was deleted.")),
         Err(e) => {
             error!("DB deletion({id}) error: {e}");
-            Err(Template::render("index", Context::err(&conn, "Failed to delete task.").await))
+            Either::Right(Template::render("index", Context::err(&conn, "Failed to delete task.").await))
         }
     }
 }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -47,7 +47,7 @@ function check_style() {
   if ! [ -z "${matches}" ]; then
     echo "Lines longer than $n characters were found in the following:"
     echo "${matches}"
-    exit 1
+    # exit 1
   fi
 
   # Ensure there's no trailing whitespace.
@@ -55,7 +55,7 @@ function check_style() {
   if ! [ -z "${matches}" ]; then
     echo "Trailing whitespace was found in the following:"
     echo "${matches}"
-    exit 1
+    # exit 1
   fi
 
   local pattern='tail -n 1 % | grep -q "^$" && echo %'
@@ -63,7 +63,7 @@ function check_style() {
   if ! [ -z "${matches}" ]; then
     echo "Trailing new line(s) found in the following:"
     echo "${matches}"
-    exit 1
+    # exit 1
   fi
 }
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -47,7 +47,7 @@ function check_style() {
   if ! [ -z "${matches}" ]; then
     echo "Lines longer than $n characters were found in the following:"
     echo "${matches}"
-    # exit 1
+    exit 1
   fi
 
   # Ensure there's no trailing whitespace.
@@ -55,7 +55,7 @@ function check_style() {
   if ! [ -z "${matches}" ]; then
     echo "Trailing whitespace was found in the following:"
     echo "${matches}"
-    # exit 1
+    exit 1
   fi
 
   local pattern='tail -n 1 % | grep -q "^$" && echo %'
@@ -63,7 +63,7 @@ function check_style() {
   if ! [ -z "${matches}" ]; then
     echo "Trailing new line(s) found in the following:"
     echo "${matches}"
-    # exit 1
+    exit 1
   fi
 }
 


### PR DESCRIPTION
I think this is the direction I want to go. It simplifies the API a bit, going from `(Status, Option<dyn TypedError>)` to `Box<dyn TypedError>`. This also eases the transition for existing code, since this is going from `Status` in 0.5 to `Box<dyn TypedError>` with this PR. `Status` implements `TypedError`, so a basic upgrade, with no additional work, is to simply wrap the `Status` in a Box.

The major reason I want to move this route, is that in most cases, the appropriate status code can be derived from the error itself. There may be a few cases where it can't, such as `std::io::Error`, which may have different meanings depending on the operation that was attempted. (E.g., normally a `NotFound` error would map to a 404 status, but if the server always expects the file to exist, it might actually map to a 500 error). These cases can pretty trivially be handled by defining useful wrappers, in much the same way as `Responder`s - and the `source()` mechanism provides a convenient way to support catching the inner type.